### PR TITLE
Use of fmtlib instead of std::format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ if(WIN32)
     add_definitions(-DNOMINMAX)
 endif()
 
+find_package(fmt CONFIG REQUIRED)
 find_package(SDL2 CONFIG REQUIRED)
 find_package(SDL2_mixer CONFIG REQUIRED)
 find_package(box2d CONFIG REQUIRED)

--- a/README.md
+++ b/README.md
@@ -28,9 +28,13 @@ VCPKG_DEFAULT_TRIPLET=x64-windows
 
 #### Install dependencies 
 ```
-./vcpkg install glm entt sdl2[alsa] sdl2-mixer box2d lua sol2
+./vcpkg install fmt glm entt sdl2[alsa] sdl2-mixer box2d lua sol2
 ```
-  * Linux `apt-get install python-jinja2`
+- Linux[debian based] `sudo apt install python-jinja2 autoconf automake libtool pkg-config libibus-1.0-dev`
+    * if[Xorg] `sudo apt install libx11-dev libxft-dev libxext-dev`
+    * if[Wayland] `sudo apt install libwayland-dev libxkbcommon-dev libegl1-mesa-dev`
+    * Optional but good practice `sudo apt install build-essentials`
+
 
 #### Clone the repository 
 ```

--- a/SCION_EDITOR/src/editor/displays/AssetDisplay.cpp
+++ b/SCION_EDITOR/src/editor/displays/AssetDisplay.cpp
@@ -134,7 +134,7 @@ void AssetDisplay::CheckRename( const std::string& sCheckName ) const
 
 	if ( bHasAsset )
 		ImGui::TextColored( ImVec4{ 1.f, 0.f, 0.f, 1.f },
-							std::format( "Asset name [{}] already exists!", sCheckName ).c_str() );
+							fmt::format( "Asset name [{}] already exists!", sCheckName ).c_str() );
 }
 
 void AssetDisplay::DrawSelectedAssets()

--- a/SCION_LOGGER/CMakeLists.txt
+++ b/SCION_LOGGER/CMakeLists.txt
@@ -5,3 +5,5 @@ add_library(SCION_LOGGER
 
 target_include_directories(
     SCION_LOGGER PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+target_link_libraries( SCION_LOGGER PUBLIC fmt::fmt)

--- a/SCION_LOGGER/include/Logger/Logger.inl
+++ b/SCION_LOGGER/include/Logger/Logger.inl
@@ -2,7 +2,7 @@
 #include "Logger.h"
 #include <chrono>
 #include <ctime>
-#include <format>
+#include <fmt/format.h>
 #include <iostream>
 #include <sstream>
 
@@ -34,7 +34,7 @@ void Logger::Log( const std::string_view message, Args&&... args )
 	}
 
 	std::stringstream ss;
-	ss << "SCION [INFO]: " << CurrentDateTime() << " - " << std::vformat( message, std::make_format_args( args... ) );
+	ss << "SCION [INFO]: " << CurrentDateTime() << " - " << fmt::vformat( message, fmt::make_format_args( args... ) );
 
 	if ( m_bConsoleLog )
 	{
@@ -68,7 +68,7 @@ void Logger::Warn( const std::string_view message, Args&&... args )
 	}
 
 	std::stringstream ss;
-	ss << "SCION [WARN]: " << CurrentDateTime() << " - " << std::vformat( message, std::make_format_args( args... ) );
+	ss << "SCION [WARN]: " << CurrentDateTime() << " - " << fmt::vformat( message, fmt::make_format_args( args... ) );
 
 	if ( m_bConsoleLog )
 	{
@@ -101,7 +101,7 @@ void Logger::Error( std::source_location location, const std::string_view messag
 	}
 
 	std::stringstream ss;
-	ss << "SCION [ERROR]: " << CurrentDateTime() << " - " << std::vformat( message, std::make_format_args( args... ) )
+	ss << "SCION [ERROR]: " << CurrentDateTime() << " - " << fmt::vformat( message, fmt::make_format_args( args... ) )
 	   << "\nFUNC: " << location.function_name() << "\nLINE: " << location.line();
 
 	if ( m_bConsoleLog )

--- a/SCION_LOGGER/src/Logger.cpp
+++ b/SCION_LOGGER/src/Logger.cpp
@@ -23,7 +23,7 @@ std::string Logger::CurrentDateTime()
 	ctime_r( &time, buf );
 #endif
 	LogTime logTime{ std::string{ buf } };
-	return std::format( "{0}-{1}-{2} {3}", logTime.year, logTime.month, logTime.dayNumber, logTime.time );
+	return fmt::format( "{0}-{1}-{2} {3}", logTime.year, logTime.month, logTime.dayNumber, logTime.time );
 }
 
 Logger& Logger::GetInstance()


### PR DESCRIPTION
Hi Dustin,

This PR to fix any error occuring on compilers not conforming 100% with std-c++20.

As of today, std::format is not widely used by compilers as clang (tested clang-16) and gcc (tested gcc-12.2) included in 'stable' debian based distros at least.
This repo is promoting the use of vcpkg, so I think it would be beneficial to use the original fmtlib to avoid give-up at first try ;).

Thanks,