### PR TITLE
Typo leading to dead code - condition always false

### DIFF
--- a/SCION_RENDERING/src/TextBatchRenderer.cpp
+++ b/SCION_RENDERING/src/TextBatchRenderer.cpp
@@ -53,7 +53,7 @@ void TextBatchRenderer::GenerateBatches()
 								textGlyph->textStr[ i ] != '!' && textGlyph->textStr[ i ] != '?' && text_size > 0 )
 						{
 							i--;
-							if ( 1 < 0 )
+							if ( i < 0 )
 							{
 								SCION_ERROR( "Failed to draw text [{}] - Wrap [{}] is too small for the text to wrap "
 											 "successfully!",


### PR DESCRIPTION
Self explanatory :)
Give a chance to this condition to be true :)

![image](https://github.com/user-attachments/assets/f53c6345-2807-48d7-8df2-206c871636e4)