### PR TITLE
Fixed compilation errors on linux (GCC & Clang)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Requires [CMake 3.26](https://cmake.org/) and [vcpkg](https://github.com/microso
 #### Get VCPKG:
 ```ps
 git clone https://github.com/microsoft/vcpkg
-./vcpkg/bootstrap-vcpkg.bat --disableMetrics
+./vcpkg/bootstrap-vcpkg.bat -disableMetrics
 ```
 #### Make sure the following environment variables are set:
 ```
@@ -69,10 +69,7 @@ VCPKG_DEFAULT_TRIPLET=x64-windows
     ```
 - Linux[debian based]
     ```
-    vcpkg install fmt glm entt glad soil2 sdl2[alsa] sdl2-mixer box2d lua sol2 stb imgui[docking-experimental,opengl3-binding,sdl2-binding]
-    ```
-    ```
-    sudo apt install python-jinja2 autoconf automake libtool pkg-config libibus-1.0-dev`
+    sudo apt install python-jinja2 autoconf automake libtool pkg-config libibus-1.0-dev
     ```
     * if[Xorg]
          ```
@@ -84,8 +81,12 @@ VCPKG_DEFAULT_TRIPLET=x64-windows
         ```
     * Optional but good practice
         ```
-        sudo apt install build-essentials
+        sudo apt install build-essential
+      
         ```
+    ```
+    vcpkg install fmt glm entt glad soil2 sdl2[alsa] sdl2-mixer box2d lua sol2 stb imgui[docking-experimental,opengl3-binding,sdl2-binding]
+    ```
 
 #### Clone the repository 
 ```

--- a/SCION_EDITOR/src/editor/displays/TilemapDisplay.cpp
+++ b/SCION_EDITOR/src/editor/displays/TilemapDisplay.cpp
@@ -25,6 +25,10 @@
 #include "Logger/Logger.h"
 #include <imgui.h>
 
+#ifdef __linux
+#include <signal.h>
+#endif
+
 using namespace SCION_CORE::Systems;
 
 namespace SCION_EDITOR
@@ -83,7 +87,11 @@ void TilemapDisplay::LoadNewScene()
 		if ( !pActiveTool->SetupTool( pCurrentScene->GetRegistryPtr(), m_pTilemapCam.get() ) )
 		{
 			SCION_ASSERT( false && "This should work!!" );
+#ifdef _WIN32
 			__debugbreak();
+#elif __linux
+			raise( SIGTRAP );
+#endif
 		}
 
 		if ( !SCENE_MANAGER().GetCurrentTileset().empty() )
@@ -108,12 +116,12 @@ void TilemapDisplay::PanZoomCamera( const glm::vec2& mousePos )
 	auto screenOffset = m_pTilemapCam->GetScreenOffset();
 	bool bOffsetChanged{ false }, bScaledChanged{ false };
 
-	if (mouse.IsBtnJustPressed(SCION_MOUSE_MIDDLE))
+	if ( mouse.IsBtnJustPressed( SCION_MOUSE_MIDDLE ) )
 	{
 		startPosition = mousePos;
 	}
 
-	if (mouse.IsBtnPressed(SCION_MOUSE_MIDDLE))
+	if ( mouse.IsBtnPressed( SCION_MOUSE_MIDDLE ) )
 	{
 		screenOffset += ( mousePos - startPosition );
 		bOffsetChanged = true;
@@ -122,13 +130,13 @@ void TilemapDisplay::PanZoomCamera( const glm::vec2& mousePos )
 	glm::vec2 currentWorldPos = m_pTilemapCam->ScreenCoordsToWorld( mousePos );
 	float scale = m_pTilemapCam->GetScale();
 
-	if (mouse.GetMouseWheelY() == 1)
+	if ( mouse.GetMouseWheelY() == 1 )
 	{
 		scale += 0.2f;
 		bScaledChanged = true;
 		bOffsetChanged = true;
 	}
-	else if (mouse.GetMouseWheelY() == -1)
+	else if ( mouse.GetMouseWheelY() == -1 )
 	{
 		scale -= 0.2f;
 		bScaledChanged = true;
@@ -152,6 +160,10 @@ void TilemapDisplay::PanZoomCamera( const glm::vec2& mousePos )
 
 TilemapDisplay::TilemapDisplay()
 	: m_pTilemapCam{ std::make_unique<SCION_RENDERING::Camera2D>() }
+{
+}
+
+TilemapDisplay::~TilemapDisplay()
 {
 }
 

--- a/SCION_EDITOR/src/editor/displays/TilemapDisplay.h
+++ b/SCION_EDITOR/src/editor/displays/TilemapDisplay.h
@@ -22,9 +22,10 @@ class TilemapDisplay : public IDisplay
 
   public:
 	TilemapDisplay();
-	~TilemapDisplay() = default;
+	virtual ~TilemapDisplay();
 
 	virtual void Draw() override;
 	virtual void Update() override;
 };
 } // namespace SCION_EDITOR
+

--- a/SCION_RENDERING/include/Rendering/Core/Camera2D.h
+++ b/SCION_RENDERING/include/Rendering/Core/Camera2D.h
@@ -21,7 +21,7 @@ class Camera2D
   public:
 	Camera2D();
 	Camera2D( int width, int height );
-	~Camera2D() = default;
+	~Camera2D();
 	/*
 	 * @brief Updates the camera's position, scale,
 	 * and rotation if needed. If there has been no changes,

--- a/SCION_RENDERING/src/Camera2D.cpp
+++ b/SCION_RENDERING/src/Camera2D.cpp
@@ -17,6 +17,10 @@ Camera2D::Camera2D()
 {
 }
 
+Camera2D::~Camera2D()
+{
+}
+
 Camera2D::Camera2D( int width, int height )
 	: m_Width{ width }
 	, m_Height{ height }


### PR DESCRIPTION
Hi Dustin, here is a PR to fix build error on linux.

Fixed compilation errors on linux (GCC & Clang):
* '__debugbreak()' is only valid on windows, added 'raise( SIGTRAP )' which is more or less the linux equivalent.
*  Even if msvc accepts it, it is normally not allowed (compiler error) to create a forward declared unique_ptr if its destructor is inlined/defaulted.

Other:
* added virtual destructor for 'TilemapDisplay'.
* fixed typos (mine :) ) in 'README.md'.

Compiles with GCC 11.3.0, GCC 12.2.0, Clang 16.0.6 on Debian.