### PR TITLE
Unsafe storage of GLuint (4 bytes) in void* (8 bytes on x64 machine)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ VCPKG_DEFAULT_TRIPLET=x64-windows
     * Optional but good practice
         ```
         sudo apt install build-essential
-      
         ```
     ```
     vcpkg install fmt glm entt glad soil2 sdl2[alsa] sdl2-mixer box2d lua sol2 stb imgui[docking-experimental,opengl3-binding,sdl2-binding]

--- a/SCION_EDITOR/src/editor/displays/AssetDisplay.cpp
+++ b/SCION_EDITOR/src/editor/displays/AssetDisplay.cpp
@@ -219,7 +219,7 @@ void AssetDisplay::DrawSelectedAssets()
 				if ( textureID == 0 )
 					break;
 
-				ImGui::ImageButton( (ImTextureID)textureID, ImVec2{ m_AssetSize, m_AssetSize } );
+				ImGui::ImageButton( (ImTextureID)(intptr_t)textureID, ImVec2{ m_AssetSize, m_AssetSize } );
 
 				if ( ImGui::IsItemHovered() && ImGui::IsMouseClicked( 0 ) && !m_bRename )
 					m_SelectedID = id;
@@ -240,7 +240,7 @@ void AssetDisplay::DrawSelectedAssets()
 											   ( strlen( sAssetName ) + 1 ) * sizeof( char ),
 											   ImGuiCond_Once );
 
-					ImGui::Image( (ImTextureID)textureID, DRAG_ASSET_SIZE );
+					ImGui::Image( (ImTextureID)(intptr_t)textureID, DRAG_ASSET_SIZE );
 					ImGui::EndDragDropSource();
 				}
 

--- a/SCION_EDITOR/src/editor/displays/SceneDisplay.cpp
+++ b/SCION_EDITOR/src/editor/displays/SceneDisplay.cpp
@@ -169,7 +169,7 @@ void SceneDisplay::Draw()
 		numStyleColors += 3;
 	}
 
-	if ( ImGui::ImageButton( (ImTextureID)pPlayTexture->GetID(),
+	if ( ImGui::ImageButton( (ImTextureID)(intptr_t)pPlayTexture->GetID(),
 							 ImVec2{
 								 (float)pPlayTexture->GetWidth() * 0.25f,
 								 (float)pPlayTexture->GetHeight() * 0.25f,
@@ -201,7 +201,7 @@ void SceneDisplay::Draw()
 
 	RenderScene();
 
-	if ( ImGui::ImageButton( (ImTextureID)pStopTexture->GetID(),
+	if ( ImGui::ImageButton( (ImTextureID)(intptr_t)pStopTexture->GetID(),
 							 ImVec2{
 								 (float)pStopTexture->GetWidth() * 0.25f,
 								 (float)pStopTexture->GetHeight() * 0.25f,
@@ -227,7 +227,7 @@ void SceneDisplay::Draw()
 
 		ImGui::SetCursorPos( ImVec2{ 0.f, 0.f } );
 
-		ImGui::Image( (ImTextureID)fb->GetTextureID(),
+		ImGui::Image( (ImTextureID)(intptr_t)fb->GetTextureID(),
 					  ImVec2{ static_cast<float>( fb->Width() ), static_cast<float>( fb->Height() ) },
 					  ImVec2{ 0.f, 1.f },
 					  ImVec2{ 1.f, 0.f } );

--- a/SCION_EDITOR/src/editor/displays/TilemapDisplay.cpp
+++ b/SCION_EDITOR/src/editor/displays/TilemapDisplay.cpp
@@ -206,7 +206,7 @@ void TilemapDisplay::Draw()
 			pActiveTool->SetOverTilemapWindow( ImGui::IsWindowHovered() );
 		}
 
-		ImGui::Image( (ImTextureID)fb->GetTextureID(), imageSize, ImVec2{ 0.f, 1.f }, ImVec2{ 1.f, 0.f } );
+		ImGui::Image( (ImTextureID)(intptr_t)fb->GetTextureID(), imageSize, ImVec2{ 0.f, 1.f }, ImVec2{ 1.f, 0.f } );
 
 		// Accept Scene Drop Target
 		if ( ImGui::BeginDragDropTarget() )

--- a/SCION_EDITOR/src/editor/displays/TilesetDisplay.cpp
+++ b/SCION_EDITOR/src/editor/displays/TilesetDisplay.cpp
@@ -88,7 +88,7 @@ void TilesetDisplay::Draw()
 				// Create unique id for the buttons
 				ImGui::PushID( k++ );
 
-				if (ImGui::ImageButton((ImTextureID)pTexture->GetID(), ImVec2{ 16.f * 1.5, 16.f * 1.5, }, ImVec2{ ux, uy }, ImVec2{ vx, vy }))
+				if (ImGui::ImageButton((ImTextureID)(intptr_t)pTexture->GetID(), ImVec2{ 16.f * 1.5f, 16.f * 1.5f, }, ImVec2{ ux, uy }, ImVec2{ vx, vy }))
 				{
 					m_Selected = id;
 					auto pActiveTool = SCENE_MANAGER().GetToolManager().GetActiveTool();


### PR DESCRIPTION
Hi,

Here we store an integer into a void* (typedef void* ImTextureID), which is usually safe except that in this case, sizeof(GLuint) < sizeof(void*).

This commit is adding an intermediate cast to prevent crash if ever textureId become negative. This should normally not happen because SOIL_load_OGL_texture_from_memory returns an unsigned int. But in case of uninitialized/invalidated GLuint id, who knows...

Explanation from msvc: https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4312

Fix on stackoverflow: https://stackoverflow.com/a/3569885/21140815

ocornut is doing the same in his examples
 - https://github.com/ocornut/imgui/wiki/Image-Loading-and-Displaying-Examples
 - https://github.com/ocornut/imgui/issues/1840#issuecomment-392313596

This will remove msvc level1 warning C4312.