### PR TITLE
Handle Relative ImGui Position

### DIFF
--- a/SCION_CORE/src/Scripting/InputManager.cpp
+++ b/SCION_CORE/src/Scripting/InputManager.cpp
@@ -221,6 +221,12 @@ void InputManager::CreateLuaInputBindings( sol::state& lua, SCION_CORE::ECS::Reg
 			return keys;
 		} );
 
+/*
+* In order for this to work in the editor, we need to take into account
+* the imgui window position, to get the world position.
+* There is new bindings inside the editor that handles this.
+*/
+#ifndef IN_SCION_EDITOR
 	auto& mouse = inputManager.GetMouse();
 
 	lua.new_usertype<Mouse>(
@@ -246,6 +252,7 @@ void InputManager::CreateLuaInputBindings( sol::state& lua, SCION_CORE::ECS::Reg
 		[ & ]() { return mouse.GetMouseWheelX(); },
 		"wheel_y",
 		[ & ]() { return mouse.GetMouseWheelY(); } );
+#endif // IN_SCION_EDITOR
 
 	lua.new_usertype<Gamepad>(
 		"Gamepad",

--- a/SCION_EDITOR/CMakeLists.txt
+++ b/SCION_EDITOR/CMakeLists.txt
@@ -94,7 +94,10 @@ add_executable(SCION_EDITOR
 	"src/editor/loaders/ProjectLoader.cpp"
 
 	${APP_ICON_RESOURCE}
- "src/editor/utilities/fonts/editor_fonts.h")
+	"src/editor/utilities/fonts/editor_fonts.h"
+	"src/editor/scripting/EditorCoreLuaWrappers.h"
+	"src/editor/scripting/EditorCoreLuaWrappers.cpp"
+)
 
 target_include_directories(
     SCION_EDITOR PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)

--- a/SCION_EDITOR/src/editor/scripting/EditorCoreLuaWrappers.cpp
+++ b/SCION_EDITOR/src/editor/scripting/EditorCoreLuaWrappers.cpp
@@ -1,0 +1,69 @@
+#include "EditorCoreLuaWrappers.h"
+#include "Core/Scripting/InputManager.h"
+#include "Core/ECS/Registry.h"
+#include "Rendering/Core/Camera2D.h"
+#include "editor/utilities/EditorUtilities.h"
+#include "Logger/Logger.h"
+
+#include <glm/glm.hpp>
+#include <imgui.h>
+#include <cmath>
+
+namespace SCION_EDITOR
+{
+void LuaCoreBinder::CreateLuaBind( sol::state& lua, SCION_CORE::ECS::Registry& registry )
+{
+	auto& mouse = INPUT_MANAGER().GetMouse();
+	auto& camera = registry.GetContext<std::shared_ptr<SCION_RENDERING::Camera2D>>();
+
+	lua.new_usertype<Mouse>(
+		"Mouse",
+		sol::no_constructor,
+		"just_pressed",
+		[ & ]( int btn ) { return mouse.IsBtnJustPressed( btn ); },
+		"just_released",
+		[ & ]( int btn ) { return mouse.IsBtnJustReleased( btn ); },
+		"pressed",
+		[ & ]( int btn ) { return mouse.IsBtnPressed( btn ); },
+		"screen_position",
+		[ & ]() {
+			const auto& mouseInfo = registry.GetContext<std::shared_ptr<MouseGuiInfo>>();
+			// If the mouse info is invalid, return the mouse screen position from SDL.
+			// This does not take into account ImGui::Docking, windowsize, relative position, etc.
+			if (!mouseInfo)
+			{
+				auto [ x, y ] = mouse.GetMouseScreenPosition();
+				return glm::vec2{ x, y };
+			}
+
+			return mouseInfo->position;
+		},
+		"world_position",
+		[ & ]() {
+			const auto& mouseInfo = registry.GetContext<std::shared_ptr<MouseGuiInfo>>();
+			// If the mouse info is invalid, return the mouse screen position from SDL.
+			// This does not take into account ImGui::Docking, windowsize, relative position, etc.
+			if (!mouseInfo)
+			{
+				auto [ x, y ] = mouse.GetMouseScreenPosition();
+				return camera->ScreenCoordsToWorld( glm::vec2{ x, y } );
+			}
+
+			float widthRatio = mouseInfo->windowSize.x / static_cast<float>(camera->GetWidth());
+			float heightRatio = mouseInfo->windowSize.y / static_cast<float>(camera->GetHeight());
+			SCION_ASSERT( widthRatio > 0 && heightRatio > 0 && "Ensure the width and heigt ratios are above zero!" );
+			int x = mouseInfo->position.x / widthRatio;
+			int y = mouseInfo->position.y / heightRatio;
+
+			return camera->ScreenCoordsToWorld( glm::vec2{ x, y } );
+		},
+		"wheel_x",
+		[ & ]() { return mouse.GetMouseWheelX(); },
+		"wheel_y",
+		[ & ]() { return mouse.GetMouseWheelY(); } );
+
+	/*
+	* TODO: Add more editor specific Core bindings here.
+	*/
+}
+} // namespace SCION_EDITOR

--- a/SCION_EDITOR/src/editor/scripting/EditorCoreLuaWrappers.h
+++ b/SCION_EDITOR/src/editor/scripting/EditorCoreLuaWrappers.h
@@ -1,0 +1,18 @@
+#pragma once
+#include <sol/sol.hpp>
+
+namespace SCION_CORE
+{
+namespace ECS
+{
+class Registry;
+}
+} // namespace SCION_CORE
+
+namespace SCION_EDITOR
+{
+struct LuaCoreBinder
+{
+	static void CreateLuaBind( sol::state& lua, SCION_CORE::ECS::Registry& registry );
+};
+} // namespace SCION_EDITOR

--- a/SCION_EDITOR/src/editor/utilities/EditorUtilities.h
+++ b/SCION_EDITOR/src/editor/utilities/EditorUtilities.h
@@ -60,6 +60,12 @@ constexpr SCION_RENDERING::Color YAXIS_HOVERED_GIZMO_COLOR = { 0, 255, 255, 175 
 
 constexpr SCION_RENDERING::Color GRAYED_OUT_GIZMO_COLOR = { 135, 135, 135, 175 };
 
+struct MouseGuiInfo
+{
+	glm::vec2 position{ 0.f };
+	glm::vec2 windowSize{ 0.f };
+};
+
 struct GizmoAxisParams
 {
 	SCION_CORE::ECS::TransformComponent transform{};

--- a/SCION_RENDERING/include/Rendering/Core/Camera2D.h
+++ b/SCION_RENDERING/include/Rendering/Core/Camera2D.h
@@ -68,6 +68,12 @@ class Camera2D
 
 	inline void SetScale( float scale )
 	{
+		// Prevent scale from being zero.
+		if ( scale <= 0.f )
+		{
+			scale = 0.1f;
+		}
+
 		m_Scale = scale;
 		m_bNeedsUpdate = true;
 	}

--- a/SCION_RENDERING/src/Camera2D.cpp
+++ b/SCION_RENDERING/src/Camera2D.cpp
@@ -74,7 +74,7 @@ glm::vec2 Camera2D::ScreenCoordsToWorld( const glm::vec2& screenCoords ) const
 	worldCoords /= m_Scale;
 
 	// Translate the camera
-	worldCoords += m_Position;
+	worldCoords += (m_Position / m_Scale);
 
 	return worldCoords;
 }


### PR DESCRIPTION
* When getting the world position from the mouse coordinates, we need to take into account the ImGui docking, window size, window position, etc.
* This was first created before the editor was started, so we did not factor that in.
* Added a new wrapper class for the mouse bindings when in editor.
* This will factor in the relative mouse position and the framebuffer size.
* Also, in the ScreenCoordsToWorld, we were not scaling the position.