### PR TITLE
Added Fix For Text Transformations

### DIFF
--- a/SCION_CORE/include/Core/CoreUtilities/CoreUtilities.h
+++ b/SCION_CORE/include/Core/CoreUtilities/CoreUtilities.h
@@ -2,8 +2,18 @@
 #include "Core/ECS/Components/AllComponents.h"
 #include <Rendering/Core/Camera2D.h>
 
+namespace SCION_RESOURCES
+{
+class AssetManager;
+}
+
 namespace SCION_CORE
 {
+
+namespace ECS
+{
+class Registry;
+}
 
 /**
  * @brief Checks if an entity is fully within the camera's view before culling.
@@ -59,5 +69,33 @@ void GenerateUVsExt( SCION_CORE::ECS::SpriteComponent& sprite, int textureWidth,
  * @return A tuple containing the isometric grid coordinates (x, y).
  */
 std::tuple<int, int> ConvertWorldPosToIsoCoords( const glm::vec2& position, const struct Canvas& canvas );
+
+/**
+ * @brief Returns the pixel size of a text block based on font metrics and wrapping settings.
+ *
+ * Calculates the width and height required to render the text from a TextComponent,
+ * using font data from the AssetManager and optional word wrapping.
+ *
+ * @param textComp Text data including string, font, and wrap width.
+ * @param transform Starting position for text rendering.
+ * @param assetManager Asset manager used to retrieve the font.
+ * @return A tuple (width, height) representing the text block size in pixels.
+ */
+std::tuple<float, float> GetTextBlockSize( const SCION_CORE::ECS::TextComponent& textComp,
+										   const SCION_CORE::ECS::TransformComponent& transform,
+										   SCION_RESOURCES::AssetManager& assetManager );
+
+/**
+ * @brief Resets the dirty flags on all necessary components in the registry.
+ * Marks updated entities as clean by clearing their `bDirty` flags.
+ */
+void UpdateDirtyEntities( SCION_CORE::ECS::Registry& registry );
+
+/* Target time per frame. Used to help clamp delta time. */
+constexpr double TARGET_FRAME_TIME = 1.0 / 60.0;
+/* Target time per frame. Used for Box2D step. */
+constexpr float TARGET_FRAME_TIME_F = 1.0f / 60.0f;
+/* Used to prevent specific loops from looping forever. */
+constexpr int SANITY_LOOP_CHECK = 100;
 
 } // namespace SCION_CORE

--- a/SCION_CORE/include/Core/ECS/Components/TextComponent.h
+++ b/SCION_CORE/include/Core/ECS/Components/TextComponent.h
@@ -14,10 +14,16 @@ struct TextComponent
 	int padding{ 0 };
 	/* The length of the text line before it will wrap to the next line. */
 	float wrap{ -1.f };
+	/* The width of the containing text box. */
+	float textBoxWidth{ -1.f };
+	/* The height of the containing text box. */
+	float textBoxHeight{ -1.f };
 	/* Color of the text. Defaults to white. */
 	SCION_RENDERING::Color color{ 255, 255, 255, 255 };
 	/* Should the text be drawn or hidden? */
 	bool bHidden{ false };
+	/* Text Component has been changed, sizes need to be updated. */
+	bool bDirty{ false };
 
 	[[nodiscard]] std::string to_string();
 

--- a/SCION_CORE/include/Core/ECS/Components/TransformComponent.h
+++ b/SCION_CORE/include/Core/ECS/Components/TransformComponent.h
@@ -14,6 +14,8 @@ struct TransformComponent
 	glm::vec2 scale{ 1.f };
 	/* The rotation of the entity in degrees. */
 	float rotation{ 0.f };
+	/* Flag to use if there are any changes. */
+	bool bDirty{ true };
 
 	[[nodiscard]] std::string to_string();
 

--- a/SCION_CORE/src/CoreUtilities/CoreUtilities.cpp
+++ b/SCION_CORE/src/CoreUtilities/CoreUtilities.cpp
@@ -3,6 +3,8 @@
 #include "Core/Scene/Scene.h"
 
 #include "ScionUtilities/MathUtilities.h"
+#include "Core/Resources/AssetManager.h"
+#include "Core/ECS/Registry.h"
 
 using namespace SCION_CORE::ECS;
 
@@ -95,6 +97,128 @@ std::tuple<int, int> ConvertWorldPosToIsoCoords( const glm::vec2& position, cons
 	int cellY = static_cast<int>( -py / diagonal );
 
 	return std::make_tuple( cellX, cellY );
+}
+
+std::tuple<float, float> GetTextBlockSize( const SCION_CORE::ECS::TextComponent& textComp,
+										   const SCION_CORE::ECS::TransformComponent& transform,
+										   SCION_RESOURCES::AssetManager& assetManager )
+{
+	const auto& pFont = assetManager.GetFont( textComp.sFontName );
+	if ( !pFont )
+	{
+		SCION_ERROR( "Failed to get font [{}] - Does not exist in asset manager!", textComp.sFontName );
+		return std::make_tuple( -1.f, -1.f );
+	}
+	float fontSize = pFont->GetFontSize();
+	// There is no wrap, find width, height is not needed.
+	if ( textComp.wrap < 0.f || textComp.wrap < fontSize )
+	{
+		glm::vec2 position{ 0.f }, temp_pos{ position };
+		for ( const auto& character : textComp.sTextStr )
+		{
+			pFont->GetNextCharPos( character, temp_pos );
+		}
+
+		const auto& paddingInfo = pFont->AveragePaddingInfo();
+		return std::make_tuple( std::abs( ( position - temp_pos ).x - ( paddingInfo.paddingX * 0.5f ) ),
+								1 * fontSize + ( paddingInfo.paddingY * 0.5f ) );
+	}
+
+	// Calculate Text boxSize
+	int numRows{ 0 };
+	glm::vec2 pos{ transform.position }, temp_pos{ pos };
+	std::string text_holder{ "" };
+
+	float wrap{ textComp.wrap };
+
+	int infiniteLoopCheck{ 0 };
+
+	for ( int i = 0; i < textComp.sTextStr.size(); i++ )
+	{
+		if ( infiniteLoopCheck >= SANITY_LOOP_CHECK )
+		{
+			SCION_ERROR( "Failed to get Text Box size correctly. Please check you text wrap, padding, textStr, etc." );
+			return std::make_tuple( -1.f, -1.f );
+		}
+
+		char character = textComp.sTextStr[ i ];
+
+		text_holder += character;
+		bool bNewLine = character == '\n';
+		size_t text_size = text_holder.size();
+		pFont->GetNextCharPos( character, temp_pos );
+
+		if ( text_size > 0 && ( temp_pos.x > ( wrap + pos.x ) || character == '\0' || bNewLine ) )
+		{
+			if ( !bNewLine )
+			{
+				while ( textComp.sTextStr[ i ] != ' ' && textComp.sTextStr[ i ] != '.' &&
+						textComp.sTextStr[ i ] != '!' && textComp.sTextStr[ i ] != '?' && text_size > 0 )
+				{
+					i--;
+					text_holder.pop_back();
+					text_size = text_holder.size();
+					infiniteLoopCheck++;
+					if ( i < 0 )
+					{
+						SCION_ERROR( "Text wrap is too small!" );
+						return std::make_tuple( -1.f, -1.f );
+					}
+				}
+			}
+			else
+			{
+				text_holder.pop_back();
+				text_size = text_holder.size();
+			}
+
+			if ( text_size > 0 )
+			{
+				if ( std::isalpha( text_holder[ 0 ] ) )
+				{
+					temp_pos = pos;
+					text_holder.clear();
+					infiniteLoopCheck = 0;
+					numRows++;
+				}
+				else
+				{
+					text_holder.erase( 0, 1 );
+					temp_pos.x -= fontSize;
+				}
+			}
+		}
+	}
+
+	if ( !text_holder.empty() )
+		numRows++;
+
+	float height = numRows * fontSize;
+	if ( height < fontSize )
+		height = fontSize;
+
+	const auto& paddingInfo = pFont->AveragePaddingInfo();
+	return std::make_tuple( wrap - paddingInfo.paddingX * 0.5f, height + paddingInfo.paddingY * 0.5f );
+}
+
+void UpdateDirtyEntities( SCION_CORE::ECS::Registry& registry )
+{
+	auto& reg = registry.GetRegistry();
+	auto view = reg.view<ECS::TransformComponent>();
+	for ( auto entity : view )
+	{
+		auto& transform = view.get<ECS::TransformComponent>( entity );
+		if ( transform.bDirty )
+		{
+			transform.bDirty = false;
+		}
+
+		if ( reg.all_of<ECS::TextComponent>( entity ) )
+		{
+			auto& text = reg.get<ECS::TextComponent>( entity );
+			text.bDirty = false;
+		}
+	}
 }
 
 } // namespace SCION_CORE

--- a/SCION_CORE/src/ECS/Components/ComponentSerializer.cpp
+++ b/SCION_CORE/src/ECS/Components/ComponentSerializer.cpp
@@ -244,7 +244,7 @@ void ComponentSerializer::DeserializeComponent( const rapidjson::Value& jsonValu
 	text.sTextStr = jsonValue[ "text" ].GetString();
 	text.sFontName = jsonValue[ "fontName" ].GetString();
 	text.padding = jsonValue[ "padding" ].GetInt();
-	text.wrap = jsonValue[ "wrap" ].GetInt();
+	text.wrap = jsonValue[ "wrap" ].GetFloat();
 	text.bHidden = jsonValue[ "bHidden" ].GetBool();
 
 	text.color = SCION_RENDERING::Color{ .r = static_cast<GLubyte>( jsonValue[ "color" ][ "r" ].GetInt() ),

--- a/SCION_CORE/src/ECS/Components/TextComponent.cpp
+++ b/SCION_CORE/src/ECS/Components/TextComponent.cpp
@@ -50,6 +50,26 @@ void SCION_CORE::ECS::TextComponent::CreateLuaTextBindings( sol::state& lua )
 		&TextComponent::wrap,
 		"color",
 		&TextComponent::color,
+		"setWrap", // Should be used instead of direct member variables
+		[]( TextComponent& text, const float wrap ) {
+			text.wrap = wrap;
+			text.bDirty = true;
+		},
+		"setText", // Should be used instead of direct member variables
+		[]( TextComponent& text, const std::string& sText ) {
+			text.sTextStr = sText;
+			text.bDirty = true;
+		},
+		"setFont", // Should be used instead of direct member variables
+		[]( TextComponent& text, const std::string& sFont ) {
+			text.sFontName = sFont;
+			text.bDirty = true;
+		},
+		"setPadding", // Should be used instead of direct member variables
+		[]( TextComponent& text, const int padding ) {
+			text.padding = padding;
+			text.bDirty = true;
+		},
 		"toString",
 		&TextComponent::to_string );
 }

--- a/SCION_CORE/src/ECS/Components/TransformComponent.cpp
+++ b/SCION_CORE/src/ECS/Components/TransformComponent.cpp
@@ -37,6 +37,16 @@ void SCION_CORE::ECS::TransformComponent::CreateLuaTransformBind( sol::state& lu
 		&TransformComponent::scale,
 		"rotation",
 		&TransformComponent::rotation,
+		"setScale", // Should be used rather than directly accessing member.
+		[]( TransformComponent& transform, const glm::vec2& scale ) {
+			transform.scale = scale;
+			transform.bDirty = true;
+		},
+		"setRotation", // Should be used rather than directly accessing member.
+		[]( TransformComponent& transform, const float rotation ) {
+			transform.rotation = rotation;
+			transform.bDirty = true;
+		},
 		"toString",
 		&TransformComponent::to_string );
 }

--- a/SCION_CORE/src/Loaders/TilemapLoader.cpp
+++ b/SCION_CORE/src/Loaders/TilemapLoader.cpp
@@ -248,6 +248,12 @@ bool TilemapLoader::SaveObjectMapJSON( SCION_CORE::ECS::Registry& registry, cons
 			SERIALIZE_COMPONENT( *pSerializer, physics );
 		}
 
+		if ( objectEnt.HasComponent<TextComponent>() )
+		{
+			const auto& text = objectEnt.GetComponent<TextComponent>();
+			SERIALIZE_COMPONENT( *pSerializer, text );
+		}
+
 		if ( auto* relations = objectEnt.TryGetComponent<Relationship>() )
 		{
 			pSerializer->StartNewObject( "relationship" );
@@ -398,6 +404,13 @@ bool TilemapLoader::LoadObjectMapJSON( SCION_CORE::ECS::Registry& registry, cons
 			const auto& jsonID = components[ "id" ];
 			auto& id = gameObject.GetComponent<Identification>();
 			DESERIALIZE_COMPONENT( jsonID, id );
+		}
+
+		if ( components.HasMember( "text" ) )
+		{
+			const auto& jsonText = components[ "text" ];
+			auto& text = gameObject.AddComponent<TextComponent>();
+			DESERIALIZE_COMPONENT( jsonText, text );
 		}
 
 		if ( components.HasMember( "relationship" ) )

--- a/SCION_CORE/src/Systems/RenderUISystem.cpp
+++ b/SCION_CORE/src/Systems/RenderUISystem.cpp
@@ -104,8 +104,7 @@ void RenderUISystem::Update( SCION_CORE::ECS::Registry& registry )
 
 	for ( auto entity : textView )
 	{
-		const auto& text = textView.get<TextComponent>( entity );
-
+		auto& text = textView.get<TextComponent>( entity );
 		if ( text.sFontName.empty() || text.bHidden )
 			continue;
 
@@ -117,9 +116,16 @@ void RenderUISystem::Update( SCION_CORE::ECS::Registry& registry )
 		}
 
 		const auto& transform = textView.get<TransformComponent>( entity );
-		const auto fontSize = pFont->GetFontSize();
 
-		glm::mat4 model = SCION_CORE::RSTModel( transform, fontSize, fontSize );
+		if ( transform.bDirty || text.bDirty )
+		{
+			const auto [ textWidth, textHeight ] = SCION_CORE::GetTextBlockSize( text, transform, assetManager );
+			text.textBoxWidth = textWidth;
+			text.textBoxHeight = textHeight;
+		}
+
+		glm::mat4 model = SCION_CORE::RSTModel( transform, text.textBoxWidth, text.textBoxHeight );
+
 		m_pTextRenderer->AddText(
 			text.sTextStr, pFont, transform.position, text.padding, text.wrap, text.color, model );
 	}

--- a/SCION_EDITOR/src/Application.cpp
+++ b/SCION_EDITOR/src/Application.cpp
@@ -30,6 +30,8 @@
 #include "editor/displays/EditorStyleToolDisplay.h"
 #include "editor/displays/ContentDisplay.h"
 
+#include "editor/scene/SceneManager.h"
+
 #include "editor/utilities/editor_textures.h"
 #include "editor/utilities/EditorFramebuffers.h"
 #include "editor/utilities/DrawComponentUtils.h"
@@ -158,7 +160,7 @@ bool Application::Initialize()
 #endif
 
 	auto& mainRegistry = MAIN_REGISTRY();
-	if ( !mainRegistry.Initialize(true) )
+	if ( !mainRegistry.Initialize( true ) )
 	{
 		SCION_ERROR( "Failed to initialize the Main Registry!" );
 		return false;
@@ -428,8 +430,7 @@ bool Application::LoadEditorTextures()
 
 	assetManager.GetTexture( "S2D_scion_logo" )->SetIsEditorTexture( true );
 
-	
-	if ( !assetManager.AddTextureFromMemory( "ZZ_S2D_PlayerStart", ZZ_S2D_PlayerStart, ZZ_S2D_PlayerStart_size) )
+	if ( !assetManager.AddTextureFromMemory( "ZZ_S2D_PlayerStart", ZZ_S2D_PlayerStart, ZZ_S2D_PlayerStart_size ) )
 	{
 		SCION_ERROR( "Failed to load texture [ZZ_S2D_PlayerStart] from memory." );
 		return false;
@@ -466,7 +467,8 @@ void Application::ProcessEvents()
 			EVENT_DISPATCHER().EmitEvent( SCION_CORE::Events::KeyEvent{
 				.key = m_Event.key.keysym.sym, .eType = SCION_CORE::Events::EKeyEventType::Pressed } );
 			break;
-		case SDL_KEYUP: keyboard.OnKeyReleased( m_Event.key.keysym.sym );
+		case SDL_KEYUP:
+			keyboard.OnKeyReleased( m_Event.key.keysym.sym );
 			EVENT_DISPATCHER().EmitEvent( SCION_CORE::Events::KeyEvent{
 				.key = m_Event.key.keysym.sym, .eType = SCION_CORE::Events::EKeyEventType::Released } );
 			break;
@@ -502,7 +504,6 @@ void Application::ProcessEvents()
 
 		// Process ImGui events after other events
 		ImGui_ImplSDL2_ProcessEvent( &m_Event );
-
 	}
 }
 
@@ -682,7 +683,7 @@ void Application::RenderDisplays()
 		pDisplay->Draw();
 	}
 
-	//Gui::ShowImGuiDemo();
+	// Gui::ShowImGuiDemo();
 }
 
 void Application::RegisterEditorMetaFunctions()
@@ -732,13 +733,14 @@ void Application::Run()
 	}
 
 	InitApp();
-	
+
 	while ( m_bIsRunning )
 	{
 		ProcessEvents();
 		Update();
 		Render();
 		UpdateInputs();
+		SCENE_MANAGER().UpdateScenes();
 	}
 
 	CleanUp();

--- a/SCION_EDITOR/src/editor/scene/SceneManager.h
+++ b/SCION_EDITOR/src/editor/scene/SceneManager.h
@@ -47,10 +47,9 @@ class EditorSceneManager : public SCION_CORE::SceneManager
 
 	bool CheckTagName( const std::string& sTagName );
 
-	inline const std::map<std::string, std::shared_ptr<SCION_CORE::Scene>>& GetAllScenes() const
-	{
-		return m_mapScenes;
-	}
+	void UpdateScenes();
+
+	inline const std::map<std::string, std::shared_ptr<SCION_CORE::Scene>>& GetAllScenes() const { return m_mapScenes; }
 
 	inline const std::string& GetCurrentTileset() const { return m_sCurrentTileset; }
 

--- a/SCION_EDITOR/src/editor/tools/gizmos/RotateGizmo.cpp
+++ b/SCION_EDITOR/src/editor/tools/gizmos/RotateGizmo.cpp
@@ -37,16 +37,22 @@ void SCION_EDITOR::RotateGizmo::Update( SCION_CORE::Canvas& canvas )
 	Entity selectedEntity{ *m_pRegistry, m_SelectedEntity };
 	auto& selectedTransform = selectedEntity.GetComponent<TransformComponent>();
 
-	selectedTransform.rotation += GetDeltaX();
+	float deltaX{ GetDeltaX() };
+	if ( deltaX > 0.f )
+	{
+		selectedTransform.rotation += deltaX;
 
-	// Clamp the values between 0 and 360.
-	if ( selectedTransform.rotation < 0.f )
-	{
-		selectedTransform.rotation = 360.f + selectedTransform.rotation;
-	}
-	else if ( selectedTransform.rotation > 360.f )
-	{
-		selectedTransform.rotation = selectedTransform.rotation - 360.f;
+		// Clamp the values between 0 and 360.
+		if ( selectedTransform.rotation < 0.f )
+		{
+			selectedTransform.rotation = 360.f + selectedTransform.rotation;
+		}
+		else if ( selectedTransform.rotation > 360.f )
+		{
+			selectedTransform.rotation = selectedTransform.rotation - 360.f;
+		}
+
+		selectedTransform.bDirty = true;
 	}
 
 	SetGizmoPosition( selectedEntity );

--- a/SCION_EDITOR/src/editor/tools/gizmos/ScaleGizmo.cpp
+++ b/SCION_EDITOR/src/editor/tools/gizmos/ScaleGizmo.cpp
@@ -39,8 +39,14 @@ void ScaleGizmo::Update( SCION_CORE::Canvas& canvas )
 	Entity selectedEntity{ *m_pRegistry, m_SelectedEntity };
 	auto& selectedTransform = selectedEntity.GetComponent<TransformComponent>();
 
-	selectedTransform.scale.x += GetDeltaX() * SCALING_FACTOR;
-	selectedTransform.scale.y += GetDeltaY() * SCALING_FACTOR;
+	float deltaX{ GetDeltaX() * SCALING_FACTOR };
+	float deltaY{ GetDeltaY() * SCALING_FACTOR };
+	if ( deltaX > 0.f || deltaY > 0.f )
+	{
+		selectedTransform.scale.x += deltaX;
+		selectedTransform.scale.y += deltaY;
+		selectedTransform.bDirty = true;
+	}
 
 	SetGizmoPosition( selectedEntity );
 

--- a/SCION_EDITOR/src/editor/utilities/DrawComponentUtils.cpp
+++ b/SCION_EDITOR/src/editor/utilities/DrawComponentUtils.cpp
@@ -61,6 +61,7 @@ void DrawComponentsUtil::DrawImGuiComponent( SCION_CORE::ECS::TransformComponent
 		if ( ImGui::InputFloat( "##scale_x", &transform.scale.x, 1.f, 1.f, "%.1f" ) )
 		{
 			transform.scale.x = std::clamp( transform.scale.x, 0.1f, 150.f );
+			transform.bDirty = true;
 		}
 		ImGui::SameLine();
 		ImGui::ColoredLabel( "y"
@@ -71,10 +72,15 @@ void DrawComponentsUtil::DrawImGuiComponent( SCION_CORE::ECS::TransformComponent
 		if ( ImGui::InputFloat( "##scale_y", &transform.scale.y, 1.f, 1.f, "%.1f" ) )
 		{
 			transform.scale.y = std::clamp( transform.scale.y, 0.1f, 150.f );
+			transform.bDirty = true;
 		}
 
 		ImGui::InlineLabel( "rotation" );
-		ImGui::InputFloat( "##rotation", &transform.rotation, 1.f, 1.f, "%.1f" );
+		if ( ImGui::InputFloat( "##rotation", &transform.rotation, 1.f, 1.f, "%.1f" ) )
+		{
+			transform.bDirty = true;
+		}
+
 		ImGui::PopItemWidth();
 		ImGui::TreePop();
 	}
@@ -558,6 +564,7 @@ void DrawComponentsUtil::DrawImGuiComponent( SCION_CORE::ECS::TextComponent& tex
 				 "##_textStr", sTextBuffer.data(), sizeof( char ) * 1024, 0 /*ImGuiInputTextFlags_EnterReturnsTrue*/ ) )
 		{
 			textComponent.sTextStr = std::string{ sTextBuffer.data() };
+			textComponent.bDirty = true;
 		}
 
 		std::string sFontName{ textComponent.sFontName };
@@ -572,6 +579,7 @@ void DrawComponentsUtil::DrawImGuiComponent( SCION_CORE::ECS::TextComponent& tex
 				{
 					sFontName = sFont;
 					textComponent.sFontName = sFontName;
+					textComponent.bDirty = true;
 				}
 			}
 
@@ -582,13 +590,13 @@ void DrawComponentsUtil::DrawImGuiComponent( SCION_CORE::ECS::TextComponent& tex
 		ImGui::InlineLabel( "padding" );
 		if ( ImGui::InputInt( "##padding", &textComponent.padding, 0, 0 ) )
 		{
-			// TODO
+			textComponent.bDirty = true;
 		}
 
 		ImGui::InlineLabel( "wrap" );
 		if ( ImGui::InputFloat( "##textWrap", &textComponent.wrap, 0.f, 0.f ) )
 		{
-			// TODO
+			textComponent.bDirty = true;
 		}
 
 		ImGui::PopItemWidth();
@@ -642,7 +650,7 @@ void DrawComponentsUtil::DrawImGuiComponent( SCION_CORE::ECS::Entity& entity,
 										 "This is the relative position based on the parent's position."
 									   : "World or absolute position of the game object." );
 
-		ImGui::ColoredLabel( "x", LABEL_SINGLE_SIZE, LABEL_RED );
+		ImGui::ColoredLabel( "x##pos_x", LABEL_SINGLE_SIZE, LABEL_RED );
 		ImGui::SameLine();
 		if ( ImGui::InputFloat(
 				 "##position_x", bHasParent ? &transform.localPosition.x : &transform.position.x, 1.f, 10.f, "%.1f" ) )
@@ -651,7 +659,7 @@ void DrawComponentsUtil::DrawImGuiComponent( SCION_CORE::ECS::Entity& entity,
 		}
 
 		ImGui::SameLine();
-		ImGui::ColoredLabel( "y", LABEL_SINGLE_SIZE, LABEL_GREEN );
+		ImGui::ColoredLabel( "y##pos_y", LABEL_SINGLE_SIZE, LABEL_GREEN );
 		ImGui::SameLine();
 		if ( ImGui::InputFloat(
 				 "##position_y", bHasParent ? &transform.localPosition.y : &transform.position.y, 1.f, 10.f, "%.1f" ) )
@@ -666,22 +674,28 @@ void DrawComponentsUtil::DrawImGuiComponent( SCION_CORE::ECS::Entity& entity,
 		}
 
 		ImGui::InlineLabel( "scale" );
-		ImGui::ColoredLabel( "x", LABEL_SINGLE_SIZE, LABEL_RED );
+		ImGui::ColoredLabel( "x##scl_x", LABEL_SINGLE_SIZE, LABEL_RED );
 		ImGui::SameLine();
 		if ( ImGui::InputFloat( "##scale_x", &transform.scale.x, 1.f, 1.f, "%.1f" ) )
 		{
 			transform.scale.x = std::clamp( transform.scale.x, 0.1f, 150.f );
+			transform.bDirty = true;
 		}
 		ImGui::SameLine();
-		ImGui::ColoredLabel( "y", LABEL_SINGLE_SIZE, LABEL_GREEN );
+		ImGui::ColoredLabel( "y##scl_y", LABEL_SINGLE_SIZE, LABEL_GREEN );
 		ImGui::SameLine();
 		if ( ImGui::InputFloat( "##scale_y", &transform.scale.y, 1.f, 1.f, "%.1f" ) )
 		{
 			transform.scale.y = std::clamp( transform.scale.y, 0.1f, 150.f );
+			transform.bDirty = true;
 		}
 
 		ImGui::InlineLabel( "rotation" );
-		ImGui::InputFloat( "##rotation", &transform.rotation, 1.f, 1.f, "%.1f" );
+		if ( ImGui::InputFloat( "##rotation", &transform.rotation, 1.f, 1.f, "%.1f" ) )
+		{
+			transform.bDirty = true;
+		}
+
 		ImGui::PopItemWidth();
 		ImGui::TreePop();
 	}

--- a/SCION_RENDERING/include/Rendering/Essentials/Font.h
+++ b/SCION_RENDERING/include/Rendering/Essentials/Font.h
@@ -1,7 +1,8 @@
 #pragma once
+#include "Vertex.h"
 #include <glm/glm.hpp>
 #include <glad/glad.h>
-#include "Vertex.h"
+#include <map>
 
 namespace SCION_RENDERING
 {
@@ -11,22 +12,42 @@ struct FontGlyph
 	Vertex max;
 };
 
+struct PaddingInfo
+{
+	float paddingX{ 0.f };
+	float paddingY{ 0.f };
+};
+
 class Font
 {
   public:
-	Font( GLuint fontAtlasID, int width, int height, float fontSize, void* data );
+	Font( GLuint fontAtlasID, int width, int height, float fontSize, void* data, float fontAscent = 0.f );
 	~Font();
 
 	FontGlyph GetGlyph( char c, glm::vec2& pos );
 	void GetNextCharPos( char c, glm::vec2& pos );
+	const PaddingInfo& GetPaddingInfoForChar( char c ) const;
+
 	inline const GLuint GetFontAtlasID() const { return m_FontAtlasID; }
 	inline const float GetFontSize() const { return m_FontSize; }
+	const PaddingInfo& AveragePaddingInfo() const { return m_AveragePadding; }
 
   private:
+	/* Opengl texture Id */
 	GLuint m_FontAtlasID;
+	/* The width of the font atlas */
 	int m_Width;
+	/* The height of the font atlas */
 	int m_Height;
+	/* The desired max size of the font. */
 	float m_FontSize;
+	/* Distance from the baseline to highest point in a glyph, in pixels. */
+	float m_FontAscent;
+	/* The underlying stbtt_bakedchar data. */
 	void* m_pData;
+	/* The average padding of all characters. */
+	PaddingInfo m_AveragePadding;
+	/* Map of each character and their padding info. */
+	std::map<char, PaddingInfo> m_mapPaddingInfo;
 };
 } // namespace SCION_RENDERING

--- a/SCION_RENDERING/src/Font.cpp
+++ b/SCION_RENDERING/src/Font.cpp
@@ -1,16 +1,39 @@
 #include "Rendering/Essentials/Font.h"
 #include <stb_truetype.h>
+#include <iostream>
 
 namespace SCION_RENDERING
 {
 
-Font::Font( GLuint fontAtlasID, int width, int height, float fontSize, void* data )
+Font::Font( GLuint fontAtlasID, int width, int height, float fontSize, void* data, float fontAscent )
 	: m_FontAtlasID{ fontAtlasID }
 	, m_Width{ width }
 	, m_Height{ height }
 	, m_FontSize{ fontSize }
+	, m_FontAscent{ fontAscent }
 	, m_pData{ std::move( data ) }
 {
+	float x{ 0.f }, y{ 0.f };
+
+	for ( int i = 32; i < 128; i++ )
+	{
+		stbtt_aligned_quad quad;
+		stbtt_GetBakedQuad( (stbtt_bakedchar*)( m_pData ), m_Width, m_Height, i - 32, &x, &y, &quad, 1 );
+
+		m_mapPaddingInfo.emplace( static_cast<char>( i ),
+								  PaddingInfo{ .paddingX = m_FontSize - ( quad.x1 - quad.x0 ),
+											   .paddingY = m_FontSize - ( quad.y1 - quad.y0 ) } );
+	}
+
+	float paddingX{ 0.f }, paddingY{ 0.f };
+	for ( const auto& [ c, paddingInfo ] : m_mapPaddingInfo )
+	{
+		paddingX += paddingInfo.paddingX;
+		paddingY += paddingInfo.paddingY;
+	}
+
+	m_AveragePadding.paddingX = std::floor( paddingX / m_mapPaddingInfo.size() );
+	m_AveragePadding.paddingY = std::floor( paddingY / m_mapPaddingInfo.size() );
 }
 
 Font::~Font()
@@ -28,11 +51,12 @@ Font::~Font()
 FontGlyph Font::GetGlyph( char c, glm::vec2& pos )
 {
 	FontGlyph glyph{};
+	float y = pos.y + m_FontAscent;
 
 	if ( c >= 32 && c < 128 )
 	{
 		stbtt_aligned_quad quad;
-		stbtt_GetBakedQuad( (stbtt_bakedchar*)( m_pData ), m_Width, m_Height, c - 32, &pos.x, &pos.y, &quad, 1 );
+		stbtt_GetBakedQuad( (stbtt_bakedchar*)( m_pData ), m_Width, m_Height, c - 32, &pos.x, &y, &quad, 1 );
 
 		glyph.min = Vertex{ .position = glm::vec2{ quad.x0, quad.y0 }, .uvs = glm::vec2{ quad.s0, quad.t0 } };
 


### PR DESCRIPTION
* Adjusted font so we can get the font ascent, padding for characters, etc.
* Added new Function to get the text box dimensions.
* Added two new dirty flags to both the transform and the text component.
* Fixed not serializing/deserializing game objects with text components.
* Set transform/text component dirty flags if changed in the editor.
* Added a UpdateScene function to reset dirty flags.
* Added sanity check to prevent infinite loops when doing text chunks/wrapping.