### PR TITLE
Add UIComponent Handling for Gizmos

### DIFF
--- a/SCION_CORE/include/Core/Systems/RenderUISystem.h
+++ b/SCION_CORE/include/Core/Systems/RenderUISystem.h
@@ -23,6 +23,7 @@ class RenderUISystem
 	~RenderUISystem();
 
 	void Update( SCION_CORE::ECS::Registry& registry );
+	inline SCION_RENDERING::Camera2D* GetCamera() { return m_pCamera2D.get(); }
 
 	static void CreateRenderUISystemLuaBind( sol::state& lua );
 

--- a/SCION_EDITOR/CMakeLists.txt
+++ b/SCION_EDITOR/CMakeLists.txt
@@ -88,6 +88,7 @@ add_executable(SCION_EDITOR
 	
 	# Events
 	"src/editor/events/EditorEventTypes.h"
+	
 	"src/editor/hub/Hub.cpp"
 	"src/editor/hub/Hub.h"
 	
@@ -99,7 +100,7 @@ add_executable(SCION_EDITOR
 	"src/editor/scripting/EditorCoreLuaWrappers.h"
 	"src/editor/scripting/EditorCoreLuaWrappers.cpp"
 	
-)
+ "src/editor/events/EditorEventTypes.cpp")
 
 target_sources(
 	SCION_EDITOR PRIVATE

--- a/SCION_EDITOR/src/editor/displays/SceneHierarchyDisplay.cpp
+++ b/SCION_EDITOR/src/editor/displays/SceneHierarchyDisplay.cpp
@@ -179,6 +179,9 @@ void SceneHierarchyDisplay::AddComponent( SCION_CORE::ECS::Entity& entity, bool*
 
 					if ( addComponent )
 					{
+						EVENT_DISPATCHER().EmitEvent( Events::AddComponentEvent{
+							.pEntity = &entity, .eType = Events::GetComponentTypeFromStr( componentStr ) } );
+
 						*bAddComponent = false;
 						ImGui::CloseCurrentPopup();
 					}
@@ -194,6 +197,10 @@ void SceneHierarchyDisplay::AddComponent( SCION_CORE::ECS::Entity& entity, bool*
 				else
 				{
 					storage->push( entity.GetEntity() );
+
+					EVENT_DISPATCHER().EmitEvent( Events::AddComponentEvent{
+						.pEntity = &entity, .eType = Events::GetComponentTypeFromStr( componentStr ) } );
+
 					*bAddComponent = false;
 					ImGui::CloseCurrentPopup();
 				}
@@ -229,7 +236,9 @@ void SceneHierarchyDisplay::DrawGameObjectDetails()
 	}
 
 	if ( m_pSelectedEntity && m_bAddComponent )
+	{
 		AddComponent( *m_pSelectedEntity, &m_bAddComponent );
+	}
 
 	if ( m_pSelectedEntity )
 	{
@@ -438,7 +447,7 @@ void SceneHierarchyDisplay::Draw()
 		{
 			if ( !pCurrentScene->AddGameObject() )
 			{
-				SCION_ERROR( "Failed to add new game object to scene [{}]", pCurrentScene->GetName() );	
+				SCION_ERROR( "Failed to add new game object to scene [{}]", pCurrentScene->GetName() );
 			}
 		}
 

--- a/SCION_EDITOR/src/editor/displays/TilemapDisplay.cpp
+++ b/SCION_EDITOR/src/editor/displays/TilemapDisplay.cpp
@@ -142,7 +142,7 @@ void TilemapDisplay::RenderTilemap()
 		pActiveTool->Draw();
 
 	if ( pActiveGizmo )
-		pActiveGizmo->Draw();
+		pActiveGizmo->Draw(renderUISystem.GetCamera());
 
 	fb->Unbind();
 	fb->CheckResize();

--- a/SCION_EDITOR/src/editor/events/EditorEventTypes.cpp
+++ b/SCION_EDITOR/src/editor/events/EditorEventTypes.cpp
@@ -1,0 +1,42 @@
+#include "EditorEventTypes.h"
+#include <map>
+
+namespace SCION_EDITOR::Events
+{
+
+// clang-format off
+static std::map<EComponentType, std::string> g_mapComponentToStr
+{
+	{ EComponentType::Transform, "TransformComponent" },
+	{ EComponentType::Sprite, "SpriteComponent" },
+	{ EComponentType::Animation, "AnimationComponent" },
+	{ EComponentType::Text, "TextComponent" },
+	{ EComponentType::UI, "UIComponent" },
+	{ EComponentType::Physics, "PhysicsComponent" },
+	{ EComponentType::RigidBody, "RigidBodyComponent" },
+	{ EComponentType::BoxCollider, "BoxColliderComponent" },
+	{ EComponentType::CircleCollider, "CircleColliderComponent" },
+	{ EComponentType::Tile, "TileComponent" }
+};
+// clang-format on
+
+EComponentType GetComponentTypeFromStr( const std::string& componentStr )
+{
+	auto itr =
+		std::ranges::find_if( g_mapComponentToStr, [ & ]( const auto& pair ) { return pair.second == componentStr; } );
+	if ( itr == g_mapComponentToStr.end() )
+		return EComponentType::NoType;
+
+	return itr->first;
+}
+
+std::string GetComponentStrFromType( EComponentType eType )
+{
+	auto itr = g_mapComponentToStr.find( eType );
+	if ( itr == g_mapComponentToStr.end() )
+		return {};
+
+	return itr->second;
+}
+
+} // namespace SCION_EDITOR::Events

--- a/SCION_EDITOR/src/editor/events/EditorEventTypes.h
+++ b/SCION_EDITOR/src/editor/events/EditorEventTypes.h
@@ -58,4 +58,28 @@ struct NameChangeEvent
 	SCION_CORE::ECS::Entity* pEntity{ nullptr };
 };
 
+enum class EComponentType
+{
+	Transform,
+	Sprite,
+	Physics,
+	Text,
+	BoxCollider,
+	CircleCollider,
+	RigidBody,
+	Animation,
+	Tile,
+	UI,
+	NoType
+};
+
+struct AddComponentEvent
+{
+	SCION_CORE::ECS::Entity* pEntity{ nullptr };
+	EComponentType eType{ EComponentType::NoType };
+};
+
+EComponentType GetComponentTypeFromStr( const std::string& componentStr );
+std::string GetComponentStrFromType( EComponentType eType );
+
 } // namespace SCION_EDITOR::Events

--- a/SCION_EDITOR/src/editor/tools/AbstractTool.h
+++ b/SCION_EDITOR/src/editor/tools/AbstractTool.h
@@ -87,6 +87,7 @@ class AbstractTool
 	inline const glm::vec2& GetMouseScreenCoords() const { return m_MouseScreenCoords; }
 	inline const glm::vec2& GetMouseWorldCoords() const { return m_MouseWorldCoords; }
 	inline const glm::vec2& GetGridCoords() const { return m_GridCoords; }
+	inline const glm::vec2& GetWindowSize() const { return m_WindowSize; }
 
 	inline void Activate() { m_bActivated = true; }
 	inline void Deactivate() { m_bActivated = false; }

--- a/SCION_EDITOR/src/editor/tools/gizmos/Gizmo.h
+++ b/SCION_EDITOR/src/editor/tools/gizmos/Gizmo.h
@@ -21,10 +21,15 @@ class SpriteBatchRenderer;
 namespace SCION_CORE::Events
 {
 class EventDispatcher;
-}
+} // namespace SCION_CORE::Events
 
 namespace SCION_EDITOR
 {
+namespace Events
+{
+struct AddComponentEvent;
+}
+
 struct GizmoAxisParams;
 
 class Gizmo : public AbstractTool
@@ -35,7 +40,7 @@ class Gizmo : public AbstractTool
 	virtual ~Gizmo();
 
 	virtual void Update( SCION_CORE::Canvas& canvas ) override;
-	virtual void Draw() = 0;
+	virtual void Draw( SCION_RENDERING::Camera2D* pCamera ) = 0;
 
 	void SetSelectedEntity( entt::entity entity );
 	void Hide();
@@ -69,5 +74,9 @@ class Gizmo : public AbstractTool
 	bool m_bHoldingY;
 	bool m_bHidden;
 	bool m_bOnlyOneAxis;
+	bool m_bUIComponent;
+
+  private:
+	void OnAddComponent( const SCION_EDITOR::Events::AddComponentEvent& addCompEvent );
 };
 } // namespace SCION_EDITOR

--- a/SCION_EDITOR/src/editor/tools/gizmos/RotateGizmo.cpp
+++ b/SCION_EDITOR/src/editor/tools/gizmos/RotateGizmo.cpp
@@ -38,7 +38,7 @@ void SCION_EDITOR::RotateGizmo::Update( SCION_CORE::Canvas& canvas )
 	auto& selectedTransform = selectedEntity.GetComponent<TransformComponent>();
 
 	float deltaX{ GetDeltaX() };
-	if ( deltaX > 0.f )
+	if ( deltaX != 0.f )
 	{
 		selectedTransform.rotation += deltaX;
 
@@ -60,7 +60,7 @@ void SCION_EDITOR::RotateGizmo::Update( SCION_CORE::Canvas& canvas )
 	ExamineMousePosition();
 }
 
-void SCION_EDITOR::RotateGizmo::Draw()
+void SCION_EDITOR::RotateGizmo::Draw( SCION_RENDERING::Camera2D* pCamera )
 {
 	if ( m_bHidden )
 		return;
@@ -70,7 +70,15 @@ void SCION_EDITOR::RotateGizmo::Draw()
 		return;
 
 	pShader->Enable();
-	auto camMat = m_pCamera->GetCameraMatrix();
+	glm::mat4 camMat{ 1.f };
+	if ( m_bUIComponent && pCamera )
+	{
+		camMat = pCamera->GetCameraMatrix();
+	}
+	else
+	{
+		camMat = m_pCamera->GetCameraMatrix();
+	}
 	pShader->SetUniformMat4( "uProjection", camMat );
 
 	m_pBatchRenderer->Begin();

--- a/SCION_EDITOR/src/editor/tools/gizmos/RotateGizmo.h
+++ b/SCION_EDITOR/src/editor/tools/gizmos/RotateGizmo.h
@@ -8,6 +8,6 @@ class RotateGizmo : public Gizmo
   public:
 	RotateGizmo();
 	virtual void Update( SCION_CORE::Canvas& canvas ) override;
-	virtual void Draw() override;
+	virtual void Draw( SCION_RENDERING::Camera2D* pCamera ) override;
 };
 } // namespace SCION_EDITOR

--- a/SCION_EDITOR/src/editor/tools/gizmos/ScaleGizmo.cpp
+++ b/SCION_EDITOR/src/editor/tools/gizmos/ScaleGizmo.cpp
@@ -41,7 +41,7 @@ void ScaleGizmo::Update( SCION_CORE::Canvas& canvas )
 
 	float deltaX{ GetDeltaX() * SCALING_FACTOR };
 	float deltaY{ GetDeltaY() * SCALING_FACTOR };
-	if ( deltaX > 0.f || deltaY > 0.f )
+	if ( deltaX != 0.f || deltaY != 0.f )
 	{
 		selectedTransform.scale.x += deltaX;
 		selectedTransform.scale.y += deltaY;
@@ -53,7 +53,7 @@ void ScaleGizmo::Update( SCION_CORE::Canvas& canvas )
 	ExamineMousePosition();
 }
 
-void ScaleGizmo::Draw()
+void ScaleGizmo::Draw( SCION_RENDERING::Camera2D* pCamera )
 {
 	if ( m_bHidden )
 		return;
@@ -63,7 +63,17 @@ void ScaleGizmo::Draw()
 		return;
 
 	pShader->Enable();
-	auto camMat = m_pCamera->GetCameraMatrix();
+
+	glm::mat4 camMat{ 1.f };
+	if ( m_bUIComponent && pCamera )
+	{
+		camMat = pCamera->GetCameraMatrix();
+	}
+	else
+	{
+		camMat = m_pCamera->GetCameraMatrix();
+	}
+
 	pShader->SetUniformMat4( "uProjection", camMat );
 
 	m_pBatchRenderer->Begin();

--- a/SCION_EDITOR/src/editor/tools/gizmos/ScaleGizmo.h
+++ b/SCION_EDITOR/src/editor/tools/gizmos/ScaleGizmo.h
@@ -8,6 +8,6 @@ class ScaleGizmo : public Gizmo
   public:
 	ScaleGizmo();
 	virtual void Update( SCION_CORE::Canvas& canvas ) override;
-	virtual void Draw() override;
+	virtual void Draw( SCION_RENDERING::Camera2D* pCamera ) override;
 };
 } // namespace SCION_EDITOR

--- a/SCION_EDITOR/src/editor/tools/gizmos/TranslateGizmo.cpp
+++ b/SCION_EDITOR/src/editor/tools/gizmos/TranslateGizmo.cpp
@@ -74,7 +74,7 @@ void TranslateGizmo::Update( SCION_CORE::Canvas& canvas )
 	ExamineMousePosition();
 }
 
-void TranslateGizmo::Draw()
+void TranslateGizmo::Draw( SCION_RENDERING::Camera2D* pCamera )
 {
 	if ( m_bHidden )
 		return;
@@ -84,7 +84,17 @@ void TranslateGizmo::Draw()
 		return;
 
 	pShader->Enable();
-	auto camMat = m_pCamera->GetCameraMatrix();
+
+	glm::mat4 camMat{ 1.f };
+	if ( m_bUIComponent && pCamera )
+	{
+		camMat = pCamera->GetCameraMatrix();
+	}
+	else
+	{
+		camMat = m_pCamera->GetCameraMatrix();
+	}
+
 	pShader->SetUniformMat4( "uProjection", camMat );
 
 	m_pBatchRenderer->Begin();

--- a/SCION_EDITOR/src/editor/tools/gizmos/TranslateGizmo.h
+++ b/SCION_EDITOR/src/editor/tools/gizmos/TranslateGizmo.h
@@ -8,6 +8,6 @@ class TranslateGizmo : public Gizmo
   public:
 	TranslateGizmo();
 	virtual void Update( SCION_CORE::Canvas& canvas ) override;
-	virtual void Draw() override;
+	virtual void Draw( SCION_RENDERING::Camera2D* pCamera ) override;
 };
 } // namespace SCION_EDITOR


### PR DESCRIPTION
* Added flag to the Gizmo Abstract class that controls if the positioning if the selected entity has a UIComponent.
* Objects that have a UI component, use a different camera.
* Added a getter for the RenderUISystem's camera.
* This camera is used when the gizmo's selected entity has a UI component.
* Created new AddComponentEvent
* Gizmo now has a handler and checks to see if the component added is a UI component.