### PR TITLE
Update editor and core Scene and SceneManager.

### DIFF
--- a/SCION_CORE/include/Core/Scene/Scene.h
+++ b/SCION_CORE/include/Core/Scene/Scene.h
@@ -86,6 +86,8 @@ class Scene
 	inline PlayerStart& GetPlayerStart() { return m_PlayerStart; }
 	inline bool IsPlayerStartEnabled() const { return m_bUsePlayerStart; }
 	inline void SetPlayerStartEnabled( bool bEnable ) { m_bUsePlayerStart = bEnable; }
+	inline const std::string& GetSceneName() const { return m_sSceneName; }
+
 
 	static void CreateLuaBind( sol::state& lua );
 

--- a/SCION_CORE/include/Core/Scene/SceneManager.h
+++ b/SCION_CORE/include/Core/Scene/SceneManager.h
@@ -3,6 +3,7 @@
 #include <vector>
 #include <map>
 #include <memory>
+#include <sol/sol.hpp>
 
 namespace SCION_CORE
 {
@@ -16,10 +17,34 @@ class SceneManager
 	SceneManager();
 	virtual ~SceneManager() {}
 
+	/**
+	 * @brief Adds a new scene to the scene manager with the given name and map type.
+	 *
+	 * Creates and stores a new Scene object if the name is not already in use. Logs an error and returns false
+	 * if a scene with the same name already exists.
+	 *
+	 * @param sSceneName The name of the scene to add.
+	 * @param eType The type of the map associated with the scene.
+	 * @return true if the scene was successfully added; false if the name already exists.
+	 */
 	virtual bool AddScene( const std::string& sSceneName, SCION_CORE::EMapType eType );
 	bool HasScene( const std::string& sSceneName );
 
+	/**
+	 * @brief Checks whether a the scene exists and returns a pointer to that scene.
+	 *
+	 * Determines if the given scene name is present in the sceneName-to-scene map.
+	 *
+	 * @param sSceneName The scene name to check.
+	 * @return a pointer to the scene if exists, nullptr otherwise.
+	 */
 	Scene* GetScene( const std::string& sSceneName );
+
+	/**
+	* @brief Returns a pointer to the current selected scene.
+	*
+	* @return pointer to the current scene if set, nullptr otherwise.
+	*/
 	Scene* GetCurrentScene();
 
 	std::vector<std::string> GetSceneNames() const;
@@ -30,6 +55,8 @@ class SceneManager
 
 	inline void SetCurrentScene( const std::string& sSceneName ) { m_sCurrentScene = sSceneName; }
 	inline const std::string& GetCurrentSceneName() const { return m_sCurrentScene; }
+
+	static void CreateLuaBind( sol::state& lua, SceneManager& sceneManager );
 
   protected:
 	std::map<std::string, std::shared_ptr<Scene>> m_mapScenes;

--- a/SCION_EDITOR/src/editor/scene/SceneManager.cpp
+++ b/SCION_EDITOR/src/editor/scene/SceneManager.cpp
@@ -208,6 +208,7 @@ void EditorSceneManager::CreateSceneManagerLuaBind( sol::state& lua )
 {
 	auto& sceneManager = SCENE_MANAGER();
 
+	// clang-format off
 	lua.new_usertype<EditorSceneManager>(
 		"SceneManager",
 		sol::no_constructor,
@@ -239,7 +240,6 @@ void EditorSceneManager::CreateSceneManagerLuaBind( sol::state& lua )
 				pScene->LoadScene();
 			}
 
-			// TODO: Check to see if this is valid
 			auto pSceneObject = dynamic_cast<SceneObject*>( pScene );
 			SCION_ASSERT( pSceneObject && "Scene Must be a valid Scene Object If run in the editor!" );
 			if ( !pSceneObject )
@@ -266,7 +266,10 @@ void EditorSceneManager::CreateSceneManagerLuaBind( sol::state& lua )
 				return pCurrentScene->GetDefaultMusicName();
 
 			return std::string{ "" };
-		} );
+		},
+		"getCurrentSceneName", [ & ] { return sceneManager.GetCurrentSceneName(); }
+	);
+	// clang-format on
 }
 
 } // namespace SCION_EDITOR

--- a/SCION_EDITOR/src/editor/scene/SceneObject.h
+++ b/SCION_EDITOR/src/editor/scene/SceneObject.h
@@ -23,7 +23,21 @@ class SceneObject : public SCION_CORE::Scene
 	 */
 	void CopySceneToRuntime();
 
+	/**
+	 * @brief Copies the passed in scene to the current scene's runtime registry.
+	 *
+	 * @param sceneToCopy - A reference to the desired scene to copy.
+	 */
 	void CopySceneToRuntime( SceneObject& sceneToCopy );
+
+	/*
+	* @brief Each scene might have it's own player start. So when changing the
+	* scenes while the scene is running, we need to copy to the current scenes
+	* runtime. We don't want to actually change the scenes. This will copy the
+	* player start from the desired scene to the current scenes registry.
+	* @param runtimeRegistry - The desired registry to copy the player start to.
+	*/
+	void CopyPlayerStartToRuntimeRegistry( SCION_CORE::ECS::Registry& runtimeRegistry );
 
 	/*
 	 * @brief Clears the runtime registry.
@@ -36,16 +50,75 @@ class SceneObject : public SCION_CORE::Scene
 	 */
 	void AddNewLayer();
 
+	/**
+	 * @brief Adds a new game object to the scene with a unique name and a default TransformComponent.
+	 *
+	 * Creates a new entity, assigns it a TransformComponent, and generates a unique name using the base
+	 * tag "GameObject" with an incremented number if needed. The entity is then stored in the scene's
+	 * tag-to-entity map.
+	 *
+	 * @return true Always returns true upon successful creation.
+	 */
 	bool AddGameObject();
+
+	/**
+	 * @brief Adds an existing entity to the scene with a specified tag.
+	 *
+	 * Inserts the given entity into the tag-to-entity map using the provided tag,
+	 * ensuring the tag does not already exist. Logs an error and returns false if
+	 * the tag is already in use.
+	 *
+	 * @param sTag The tag to associate with the entity.
+	 * @param entity The entity to add, which must be valid (not entt::null).
+	 * @return true if the entity was successfully added; false if the tag already exists.
+	 */
 	bool AddGameObjectByTag( const std::string& sTag, entt::entity entity );
+
+	/**
+	 * @brief Duplicates an existing game object by copying all of its components to a new entity.
+	 *
+	 * Searches for the given entity in the tag-to-entity map, and if found, creates a new entity
+	 * in the registry and copies all of the original entity's components using registered meta functions.
+	 * The duplicated entity is given a unique name based on the original tag and added to the map.
+	 *
+	 * @param entity The entity to duplicate.
+	 * @return true if the duplication was successful; false if the original entity was not found in the map.
+	 */
 	bool DuplicateGameObject( entt::entity entity );
+
+	/**
+	 * @brief Deletes a game object and its hierarchy from the scene using the specified tag.
+	 *
+	 * Locates the entity associated with the given tag and removes it, along with any related child entities,
+	 * from the registry using RelationshipUtils. All affected tags are then removed from the tag-to-entity map.
+	 *
+	 * @param sTag The tag identifying the entity to delete.
+	 * @return true if the entity and its relationships were successfully removed; false if the tag was not found.
+	 */
 	bool DeleteGameObjectByTag( const std::string& sTag );
+
+	/**
+	 * @brief Deletes a game object and its hierarchy from the scene using the specified entity ID.
+	 *
+	 * Searches for the tag associated with the given entity, then removes the entity and any of its
+	 * related children using RelationshipUtils. All corresponding tags are erased from the tag-to-entity map.
+	 *
+	 * @param entity The entity to delete.
+	 * @return true if the entity and its relationships were successfully removed; false if the entity was not found.
+	 */
 	bool DeleteGameObjectById( entt::entity entity );
 
 	virtual bool LoadScene() override;
 	virtual bool UnloadScene( bool bSaveScene = true ) override;
-	
 
+	/**
+	 * @brief Checks whether a tag name already exists in the scene.
+	 *
+	 * Determines if the given tag is present in the tag-to-entity map.
+	 *
+	 * @param sTagName The tag name to check.
+	 * @return true if the tag exists; false otherwise.
+	 */
 	bool CheckTagName( const std::string& sTagName );
 
 	inline const std::string& GetName() { return m_sSceneName; }
@@ -54,7 +127,6 @@ class SceneObject : public SCION_CORE::Scene
 
   private:
 	void OnEntityNameChanges( SCION_EDITOR::Events::NameChangeEvent& nameChange );
-	
 
   private:
 	/* The runtime registry. This registry starts with the current scene's data;


### PR DESCRIPTION
* Added ability to create the player start based on the desired scene.
* Added/started the Core SceneManager lua bind. The core bindings will differ from the editor. The core bindings will need to be fully tested once the runtime exe is created.
* Fixed not setting the actual scene name when creating a scene object.
* Fixed crash for trying to copy an uneditable entity.