### PR TITLE
Remove assets from asset manager after file delete.

### DIFF
--- a/SCION_CORE/include/Core/Resources/AssetManager.h
+++ b/SCION_CORE/include/Core/Resources/AssetManager.h
@@ -225,6 +225,18 @@ class AssetManager
 	 */
 	bool DeleteAsset( const std::string& sAssetName, SCION_UTIL::AssetType eAssetType );
 
+	/**
+	 * @brief Searches for an asset by file path across textures, music, and sound effects
+	 * and deletes the matching asset if found.
+	 * @brief The function iterates through internal maps of loaded textures, music tracks,
+	 * and sound effects, comparing each asset's path or filename with the given path.
+	 * If a match is found, the corresponding asset is deleted using the appropriate type.
+	 *
+	 * @param sAssetPath The full path or filename of the asset to delete.
+	 * @return true if the asset is not found or successfully deleted; false if deletion fails.
+	 */
+	bool DeleteAssetFromPath( const std::string& sAssetPath );
+
 	/*
 	 * Binds the AssetManager functionality to the lua state.
 	 * @param takes in the sol::state& for binding to lua.

--- a/SCION_CORE/src/Resources/AssetManager.cpp
+++ b/SCION_CORE/src/Resources/AssetManager.cpp
@@ -537,7 +537,44 @@ bool AssetManager::DeleteAsset( const std::string& sAssetName, SCION_UTIL::Asset
 		}
 	}
 
+	if (bSuccess)
+	{
+		SCION_LOG( "Deleted asset [{}]", sAssetName );
+	}
+
 	return bSuccess;
+}
+
+bool AssetManager::DeleteAssetFromPath( const std::string& sAssetPath )
+{
+	auto textureItr = std::ranges::find_if(
+		m_mapTextures, [ & ]( const auto& pair ) { return pair.second->GetPath() == sAssetPath; } );
+
+	if ( textureItr != m_mapTextures.end() )
+	{
+		std::string sTextureName{ textureItr->first };
+		return DeleteAsset( sTextureName, SCION_UTIL::AssetType::TEXTURE );
+	}
+
+	auto musicItr = std::ranges::find_if(
+		m_mapMusic, [ & ]( const auto& pair ) { return pair.second->GetFilename() == sAssetPath; } );
+
+	if ( musicItr != m_mapMusic.end() )
+	{
+		std::string sMusicName{ musicItr->first };
+		return DeleteAsset( sMusicName, SCION_UTIL::AssetType::MUSIC );
+	}
+
+	auto soundItr = std::ranges::find_if(
+		m_mapSoundFx, [ & ]( const auto& pair ) { return pair.second->GetFilename() == sAssetPath; } );
+
+	if ( soundItr != m_mapSoundFx.end() )
+	{
+		std::string sSoundName{ soundItr->first };
+		return DeleteAsset( sSoundName, SCION_UTIL::AssetType::SOUNDFX );
+	}
+
+	return true;
 }
 
 void AssetManager::CreateLuaAssetManager( sol::state& lua )
@@ -596,6 +633,9 @@ void AssetManager::FileWatcher()
 		{
 			std::shared_lock sharedLock{ m_AssetMutex };
 			fs::path path{ fileParam.sFilepath };
+			if ( !fs::exists( path ) )
+				continue;
+
 			if ( fileParam.lastWrite != fs::last_write_time( path ) )
 			{
 				sharedLock.unlock();


### PR DESCRIPTION
* If the user deletes a file that was already in the asset manager, from the content browser. We have to remove the asset from the AssetManager.
* The asset name might not be the same as the filename because the user can store the asset under any name.
* So we have to find the asset using the path. So we check to see what the path is for the file being deleted and check against that path in the asset manager asset maps.
* We also need to ensure the asset is removed from the file watcher.