### PR TITLE
Added Fix for Buggy gizmos

### DIFF
--- a/SCION_CORE/include/Core/Scene/Scene.h
+++ b/SCION_CORE/include/Core/Scene/Scene.h
@@ -93,7 +93,7 @@ class Scene
 
   protected:
 	bool LoadSceneData();
-	bool SaveSceneData();
+	bool SaveSceneData(bool bOverride = false);
 	void SetCanvasOffset();
 	
   protected:

--- a/SCION_CORE/src/Loaders/TilemapLoader.cpp
+++ b/SCION_CORE/src/Loaders/TilemapLoader.cpp
@@ -486,7 +486,9 @@ bool TilemapLoader::SaveTilemap( SCION_CORE::ECS::Registry& registry, const std:
 bool TilemapLoader::LoadTilemap( SCION_CORE::ECS::Registry& registry, const std::string& sTilemapFile, bool bUseJSON )
 {
 	if ( bUseJSON )
+	{
 		return LoadTilemapJSON( registry, sTilemapFile );
+	}
 
 	return false;
 }
@@ -495,7 +497,9 @@ bool TilemapLoader::LoadGameObjects( SCION_CORE::ECS::Registry& registry, const 
 									 bool bUseJSON )
 {
 	if ( bUseJSON )
+	{
 		return LoadObjectMapJSON( registry, sObjectMapFile );
+	}
 
 	return false;
 }

--- a/SCION_CORE/src/Scene/Scene.cpp
+++ b/SCION_CORE/src/Scene/Scene.cpp
@@ -95,12 +95,11 @@ Scene::Scene( const std::string& sceneName, EMapType eType )
 	SCION_ASSERT( sceneData.is_open() && "File should have been created and opened." );
 	sceneData.close();
 
-	SaveSceneData();
+	SaveSceneData( true );
 }
 
 bool Scene::LoadScene()
 {
-	SCION_LOG( "LOADED SCENE" );
 	if ( m_bSceneLoaded )
 	{
 		SCION_ERROR( "Scene [{}] has already been loaded", m_sSceneName );
@@ -125,6 +124,7 @@ bool Scene::LoadScene()
 	}
 
 	m_bSceneLoaded = true;
+	SCION_LOG( "Loaded Scene: {}", m_sSceneName );
 	return true;
 }
 
@@ -302,13 +302,13 @@ bool Scene::LoadSceneData()
 	return true;
 }
 
-bool Scene::SaveSceneData()
+bool Scene::SaveSceneData( bool bOverride )
 {
 	/*
 	 * Scenes that have not been loaded do not need to be re-saved. They would have been
 	 * saved when unloading the scene previously. Only save loaded scenes.
 	 */
-	if ( !m_bSceneLoaded )
+	if ( !m_bSceneLoaded && !bOverride )
 	{
 		return true;
 	}

--- a/SCION_EDITOR/src/editor/tools/gizmos/Gizmo.cpp
+++ b/SCION_EDITOR/src/editor/tools/gizmos/Gizmo.cpp
@@ -169,7 +169,7 @@ void Gizmo::ExamineMousePosition()
 	const auto& xAxisTransform = m_pXAxisParams->transform;
 	auto& xAxisSprite = m_pXAxisParams->sprite;
 
-	if ( mousePos.x >= xAxisTransform.position.x &&
+	if ( !m_bHoldingY && mousePos.x >= xAxisTransform.position.x &&
 		 mousePos.x <= ( xAxisTransform.position.x + ( xAxisSprite.width * xAxisTransform.scale.x ) ) &&
 		 mousePos.y >= xAxisTransform.position.y &&
 		 mousePos.y <= ( xAxisTransform.position.y + ( xAxisSprite.height * xAxisTransform.scale.y ) ) )
@@ -200,7 +200,7 @@ void Gizmo::ExamineMousePosition()
 	const auto& yAxisTransform = m_pYAxisParams->transform;
 	auto& yAxisSprite = m_pYAxisParams->sprite;
 
-	if ( mousePos.x >= yAxisTransform.position.x &&
+	if ( !m_bHoldingX && mousePos.x >= yAxisTransform.position.x &&
 		 mousePos.x <= ( yAxisTransform.position.x + ( yAxisSprite.width * yAxisTransform.scale.x ) ) &&
 		 mousePos.y >= yAxisTransform.position.y &&
 		 mousePos.y <= ( yAxisTransform.position.y + ( yAxisSprite.height * yAxisTransform.scale.y ) ) )
@@ -227,7 +227,7 @@ void Gizmo::ExamineMousePosition()
 
 float Gizmo::GetDeltaX()
 {
-	if ( !IsOverTilemapWindow() || OutOfBounds() )
+	if ( !IsOverTilemapWindow() || m_bHoldingY )
 		return 0.f;
 
 	if ( !m_bOverXAxis && !m_bHoldingX )
@@ -246,11 +246,11 @@ float Gizmo::GetDeltaX()
 			mousePosX *= ratioX;
 			m_LastMousePos.x *= ratioX;
 
-			return std::ceil( mousePosX - m_LastMousePos.x );
+			return mousePosX - m_LastMousePos.x;
 		}
 		else
 		{
-			return std::ceil( ( GetMouseScreenCoords().x - m_LastMousePos.x ) / m_pCamera->GetScale() );
+			return ( GetMouseScreenCoords().x - m_LastMousePos.x ) / m_pCamera->GetScale(); 
 		}
 	}
 
@@ -264,7 +264,7 @@ float Gizmo::GetDeltaX()
 
 float Gizmo::GetDeltaY()
 {
-	if ( !IsOverTilemapWindow() || OutOfBounds() || m_bOnlyOneAxis )
+	if ( !IsOverTilemapWindow() || m_bOnlyOneAxis || m_bHoldingX )
 		return 0.f;
 
 	if ( !m_bOverYAxis && !m_bHoldingY )
@@ -283,11 +283,11 @@ float Gizmo::GetDeltaY()
 			mousePosY *= ratioY;
 			m_LastMousePos.y *= ratioY;
 
-			return std::ceil( mousePosY - m_LastMousePos.y );
+			return mousePosY - m_LastMousePos.y;
 		}
 		else
 		{
-			return std::ceil( ( GetMouseScreenCoords().y - m_LastMousePos.y ) / m_pCamera->GetScale() );
+			return ( GetMouseScreenCoords().y - m_LastMousePos.y ) / m_pCamera->GetScale();
 		}
 	}
 

--- a/SCION_EDITOR/src/editor/tools/gizmos/ScaleGizmo.cpp
+++ b/SCION_EDITOR/src/editor/tools/gizmos/ScaleGizmo.cpp
@@ -14,7 +14,7 @@
 using namespace SCION_CORE::ECS;
 
 // TODO: Add a scaling factor to the editor for all gizmos.
-constexpr float SCALING_FACTOR = 0.01f;
+constexpr float SCALING_FACTOR = 0.1f;
 
 namespace SCION_EDITOR
 {
@@ -44,7 +44,7 @@ void ScaleGizmo::Update( SCION_CORE::Canvas& canvas )
 	if ( deltaX != 0.f || deltaY != 0.f )
 	{
 		selectedTransform.scale.x += deltaX;
-		selectedTransform.scale.y += deltaY;
+		selectedTransform.scale.y -= deltaY;
 		selectedTransform.bDirty = true;
 	}
 


### PR DESCRIPTION
* Removed out of bounds check. The game object can now be moved off of the canvas.
* Prevent X/Y gizmos from being active at the same time.
* Removed the std::ceil from the Delta values. This was causing the object to move much faster that the mouse.
* Adjust scale gizmo scaling factor and scaling in Y direction.
* Added flag to Scene::LoadScene function to override the loaded check. This should be used when first creating a scene so the scene data file is created.