### PR TITLE
Update To Save UI Component For Game Objects

### DIFF
--- a/SCION_CORE/include/Core/ECS/Components/ComponentSerializer.h
+++ b/SCION_CORE/include/Core/ECS/Components/ComponentSerializer.h
@@ -38,6 +38,7 @@ class ComponentSerializer
 	static void SerializeComponent( SCION_FILESYSTEM::JSONSerializer& serializer, const PhysicsComponent& physics );
 	static void SerializeComponent( SCION_FILESYSTEM::JSONSerializer& serializer, const RigidBodyComponent& rigidBody );
 	static void SerializeComponent( SCION_FILESYSTEM::JSONSerializer& serializer, const Identification& id);
+	static void SerializeComponent( SCION_FILESYSTEM::JSONSerializer& serializer, const UIComponent& id);
 
 	static void DeserializeComponent( const rapidjson::Value& jsonValue, TransformComponent& transform );
 	static void DeserializeComponent( const rapidjson::Value& jsonValue, SpriteComponent& sprite );
@@ -48,6 +49,7 @@ class ComponentSerializer
 	static void DeserializeComponent( const rapidjson::Value& jsonValue, PhysicsComponent& physics );
 	static void DeserializeComponent( const rapidjson::Value& jsonValue, RigidBodyComponent& rigidBody );
 	static void DeserializeComponent( const rapidjson::Value& jsonValue, Identification& id);
+	static void DeserializeComponent( const rapidjson::Value& jsonValue, UIComponent& id);
 };
 
 } // namespace SCION_CORE::ECS

--- a/SCION_CORE/include/Core/ECS/Components/TextComponent.h
+++ b/SCION_CORE/include/Core/ECS/Components/TextComponent.h
@@ -6,8 +6,8 @@ namespace SCION_CORE::ECS
 {
 struct TextComponent
 {
-	/* The name of the font to use. This must exist in the Asset Manager. */
-	std::string sFontName{ "pixel" };
+	/* The name of the font to use. This must exist in the Asset Manager. Defaults to pixel-32. */
+	std::string sFontName{ "pixel-32" };
 	/* The actual string value to be drawn to the screen. */
 	std::string sTextStr{};
 	/* Any padding to be used around the text. */

--- a/SCION_CORE/src/ECS/Components/ComponentSerializer.cpp
+++ b/SCION_CORE/src/ECS/Components/ComponentSerializer.cpp
@@ -176,6 +176,14 @@ void ComponentSerializer::SerializeComponent( SCION_FILESYSTEM::JSONSerializer& 
 		.EndObject(); // End id table
 }
 
+void ComponentSerializer::SerializeComponent( SCION_FILESYSTEM::JSONSerializer& serializer, const UIComponent& id )
+{
+	serializer.StartNewObject( "ui" ).EndObject();
+	// TODO: Add more members as needed.
+	// Currently the UIComponent only has a type; however, it is not currently used.
+	// The UI Component is currently only used as a flag for UI Rendering
+}
+
 void ComponentSerializer::DeserializeComponent( const rapidjson::Value& jsonValue, TransformComponent& transform )
 {
 	transform.position =
@@ -298,6 +306,14 @@ void ComponentSerializer::DeserializeComponent( const rapidjson::Value& jsonValu
 {
 	id.name = jsonValue[ "name" ].GetString();
 	id.group = jsonValue[ "group" ].GetString();
+}
+
+void ComponentSerializer::DeserializeComponent( const rapidjson::Value& jsonValue, UIComponent& ui )
+{
+	ui.eType = UIObjectType::NO_TYPE;
+	// TODO: Add more members as needed.
+	// Currently the UIComponent only has a type; however, it is not currently used.
+	// The UI Component is currently only used as a flag for UI Rendering
 }
 
 } // namespace SCION_CORE::ECS

--- a/SCION_CORE/src/Loaders/TilemapLoader.cpp
+++ b/SCION_CORE/src/Loaders/TilemapLoader.cpp
@@ -254,6 +254,12 @@ bool TilemapLoader::SaveObjectMapJSON( SCION_CORE::ECS::Registry& registry, cons
 			SERIALIZE_COMPONENT( *pSerializer, text );
 		}
 
+		if (objectEnt.HasComponent<UIComponent>())
+		{
+			const auto& ui = objectEnt.GetComponent<UIComponent>();
+			SERIALIZE_COMPONENT( *pSerializer, ui );
+		}
+
 		if ( auto* relations = objectEnt.TryGetComponent<Relationship>() )
 		{
 			pSerializer->StartNewObject( "relationship" );
@@ -411,6 +417,13 @@ bool TilemapLoader::LoadObjectMapJSON( SCION_CORE::ECS::Registry& registry, cons
 			const auto& jsonText = components[ "text" ];
 			auto& text = gameObject.AddComponent<TextComponent>();
 			DESERIALIZE_COMPONENT( jsonText, text );
+		}
+
+		if (components.HasMember("ui"))
+		{
+			const auto& jsonUI = components[ "ui" ];
+			auto& ui = gameObject.AddComponent<UIComponent>();
+			DESERIALIZE_COMPONENT( jsonUI, ui );
 		}
 
 		if ( components.HasMember( "relationship" ) )

--- a/SCION_EDITOR/src/editor/displays/SceneHierarchyDisplay.cpp
+++ b/SCION_EDITOR/src/editor/displays/SceneHierarchyDisplay.cpp
@@ -117,8 +117,8 @@ void SceneHierarchyDisplay::AddComponent( SCION_CORE::ECS::Entity& entity, bool*
 			componentMap[ id ] = std::string{ name };
 		}
 
-		static std::string componentStr{  };
-		static std::string componentStrPrev{ };
+		static std::string componentStr{};
+		static std::string componentStrPrev{};
 		static entt::id_type id_type{ 0 };
 		static bool bError{ false };
 
@@ -416,6 +416,17 @@ void SceneHierarchyDisplay::OnKeyPressed( SCION_CORE::Events::KeyEvent& keyEvent
 	}
 }
 
+void SceneHierarchyDisplay::OnAddComponent( SCION_EDITOR::Events::AddComponentEvent& addCompEvent )
+{
+	if ( addCompEvent.pEntity && addCompEvent.eType == Events::EComponentType::Text )
+	{
+		if ( !addCompEvent.pEntity->HasComponent<UIComponent>() )
+		{
+			addCompEvent.pEntity->AddComponent<UIComponent>();
+		}
+	}
+}
+
 void SceneHierarchyDisplay::OpenContext( SceneObject* pCurrentScene )
 {
 	if ( !pCurrentScene )
@@ -471,7 +482,7 @@ void SceneHierarchyDisplay::OpenContext( SceneObject* pCurrentScene )
 		}
 	}
 
-	if ( ImGui::IsWindowFocused() && !ImGui::IsAnyItemHovered() &&
+	if ( m_bWindowActive && ImGui::IsWindowHovered() && !ImGui::IsAnyItemHovered() &&
 		 ( ImGui::IsMouseClicked( ImGuiMouseButton_Left ) || ImGui::IsMouseClicked( ImGuiMouseButton_Right ) ) )
 	{
 		m_pSelectedEntity = nullptr;
@@ -482,11 +493,10 @@ SceneHierarchyDisplay::SceneHierarchyDisplay()
 {
 	ADD_SWE_HANDLER( Events::SwitchEntityEvent, &SceneHierarchyDisplay::OnEntityChanged, *this );
 	ADD_EVENT_HANDLER( KeyEvent, &SceneHierarchyDisplay::OnKeyPressed, *this );
+	ADD_EVENT_HANDLER( Events::AddComponentEvent, &SceneHierarchyDisplay::OnAddComponent, *this )
 }
 
-SceneHierarchyDisplay::~SceneHierarchyDisplay()
-{
-}
+SceneHierarchyDisplay::~SceneHierarchyDisplay() = default;
 
 void SceneHierarchyDisplay::Update()
 {
@@ -502,6 +512,7 @@ void SceneHierarchyDisplay::Draw()
 	}
 
 	m_bWindowActive = ImGui::IsWindowFocused();
+
 	OpenContext( pCurrentScene );
 
 	ImGui::Separator();

--- a/SCION_EDITOR/src/editor/displays/SceneHierarchyDisplay.h
+++ b/SCION_EDITOR/src/editor/displays/SceneHierarchyDisplay.h
@@ -10,6 +10,7 @@ class Entity;
 namespace SCION_EDITOR::Events
 {
 struct SwitchEntityEvent;
+struct AddComponentEvent;
 }
 
 namespace SCION_CORE::Events
@@ -41,9 +42,10 @@ class SceneHierarchyDisplay : public IDisplay
 
 	void OnEntityChanged( SCION_EDITOR::Events::SwitchEntityEvent& swEntEvent );
 	void OnKeyPressed( SCION_CORE::Events::KeyEvent& keyEvent );
+	void OnAddComponent( SCION_EDITOR::Events::AddComponentEvent& addCompEvent );
 
 	void OpenContext( class SceneObject* pCurrentScene );
-
+	
   private:
 	std::shared_ptr<SCION_CORE::ECS::Entity> m_pSelectedEntity{ nullptr };
 	ImGuiTextFilter m_TextFilter;

--- a/SCION_EDITOR/src/editor/tools/gizmos/Gizmo.cpp
+++ b/SCION_EDITOR/src/editor/tools/gizmos/Gizmo.cpp
@@ -250,7 +250,7 @@ float Gizmo::GetDeltaX()
 		}
 		else
 		{
-			return ( GetMouseScreenCoords().x - m_LastMousePos.x ) / m_pCamera->GetScale(); 
+			return ( GetMouseScreenCoords().x - m_LastMousePos.x ) / m_pCamera->GetScale();
 		}
 	}
 
@@ -339,7 +339,7 @@ void Gizmo::SetGizmoPosition( SCION_CORE::ECS::Entity& selectedEntity )
 
 void Gizmo::OnAddComponent( const SCION_EDITOR::Events::AddComponentEvent& addCompEvent )
 {
-	if ( addCompEvent.eType == Events::EComponentType::UI )
+	if ( addCompEvent.eType == Events::EComponentType::UI || addCompEvent.eType == Events::EComponentType::Text )
 	{
 		m_bUIComponent = true;
 	}


### PR DESCRIPTION
* Added JSON Serialization/Deserialization for UIComponents.
  * UI Components are bare bones right now, but it will be updated to accommodate other UI Objects.
* Added checks for UI Components in the tilemap loader.
* Fixed issue with selected entity being deselected when clicking on a separate window.
* Added event handler for adding text components. If the component being added is a text component, it will automatically add the UI component.