### PR TITLE
Add Fix for Content Display Folder Select Crash

### DIFF
--- a/SCION_EDITOR/src/editor/displays/ContentDisplay.cpp
+++ b/SCION_EDITOR/src/editor/displays/ContentDisplay.cpp
@@ -266,12 +266,25 @@ void ContentDisplay::DrawToolbar()
 	std::string pathStr{ m_CurrentDir.string() };
 	std::string pathToSplit = pathStr.substr( pathStr.find( savedPath ) + savedPath.size() );
 	auto dir = SplitStr( pathToSplit, PATH_SEPARATOR );
+
+	// List all of the folders as buttons -- TODO: Possibly Truncate folders if too deep.
 	for ( size_t i = 0; i < dir.size(); i++ )
 	{
-		if ( ImGui::Button( dir[ i ].c_str() ) )
+		// Folders can have the same name if they are not in the same folder.
+		// This will cause an ImGui issue because a button has the same ID. Append the index to the folder name.
+		std::string sFolderName{ fmt::format( "{}##_{}", dir[ i ], i ) };
+		if ( ImGui::Button( sFolderName.c_str() ) )
 		{
-			std::string pathChange = pathStr.substr( 0, pathStr.find( dir[ i ] ) + dir[ i ].size() );
-			m_CurrentDir = fs::path{ pathChange };
+			fs::path rebuildPath;
+			for ( size_t j = 0; j <= i; j++ )
+			{
+				rebuildPath /= dir[ j ];
+			}
+
+			fs::path finalPath{ savedPath };
+			finalPath /= rebuildPath;
+
+			m_CurrentDir = finalPath;
 		}
 
 		ImGui::SameLine();
@@ -282,7 +295,9 @@ void ContentDisplay::DrawToolbar()
 		ImGui::PopStyleColor( 3 );
 
 		if ( i < dir.size() - 1 )
+		{
 			ImGui::SameLine();
+		}
 	}
 
 	ImGui::Separator();


### PR DESCRIPTION
* When there were folders with the same name as the project, previously we were trying to take a substr of the path we wanted to find at a specific index.
* The issue with this was, it would find the project path first and then stop there.
* This would in turn cause the crash.
* Changed to use the pathToSplit created previously and rebuild the path up to the current index selected.
* This will handle multiple folders deep with the same name.
* Also added index to the folder name with ##.
* Child folders can have the same name as the parent; however, with an ImGui button, this was resulting in buttons with the same ID.