### PR TITLE
Move Check to tilemap editor

### DIFF
--- a/SCION_CORE/src/Systems/AnimationSystem.cpp
+++ b/SCION_CORE/src/Systems/AnimationSystem.cpp
@@ -3,7 +3,6 @@
 #include "Core/ECS/Components/SpriteComponent.h"
 #include "Core/ECS/Components/TransformComponent.h"
 #include "Core/CoreUtilities/CoreUtilities.h"
-#include "Core/CoreUtilities/CoreEngineData.h"
 #include "Core/ECS/Registry.h"
 
 #include "Logger/Logger.h"
@@ -18,10 +17,6 @@ namespace SCION_CORE::Systems
 
 void AnimationSystem::Update( SCION_CORE::ECS::Registry& registry, SCION_RENDERING::Camera2D& camera )
 {
-
-	if ( !CORE_GLOBALS().AnimationRenderEnabled() )
-		return;
-
 	auto view = registry.GetRegistry().view<AnimationComponent, SpriteComponent, TransformComponent>();
 	if ( view.size_hint() < 1 )
 		return;

--- a/SCION_EDITOR/src/editor/displays/TilemapDisplay.cpp
+++ b/SCION_EDITOR/src/editor/displays/TilemapDisplay.cpp
@@ -602,9 +602,12 @@ void TilemapDisplay::Update()
 		pActiveGizmo->Update( pCurrentScene->GetCanvas() );
 	}
 
-	auto& mainRegistry = MAIN_REGISTRY();
-	auto& animationSystem = mainRegistry.GetAnimationSystem();
-	animationSystem.Update( pCurrentScene->GetRegistry(), *m_pTilemapCam );
+	if ( CORE_GLOBALS().AnimationRenderEnabled() )
+	{
+		auto& mainRegistry = MAIN_REGISTRY();
+		auto& animationSystem = mainRegistry.GetAnimationSystem();
+		animationSystem.Update( pCurrentScene->GetRegistry(), *m_pTilemapCam );
+	}
 
 	m_pTilemapCam->Update();
 


### PR DESCRIPTION
* We only want to stop the animations in the tilemap editor, not when running the scene.